### PR TITLE
Reset command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.4'
+def runeLiteVersion = '1.7.7'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -130,6 +130,9 @@ public class HydrateReminderPlugin extends Plugin
 					case "prev":
 						handleHydratePrevCommand();
 						break;
+					case "reset":
+						handleHydrateResetCommand();
+						break;
 					default:
 						log.warn(String.format("%s is not a supported argument for the hydrate command", args[0]));
 						break;
@@ -171,6 +174,19 @@ public class HydrateReminderPlugin extends Plugin
 		final String timeString = String.format("%s hours %s minutes %s seconds since the last hydrate break",
 				hours, minutes, seconds);
 		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", timeString, null);
+	}
+
+	/**
+	 * <p>Handle the hydrate reset command by resetting the current hydrate interval and displaying
+	 * a reset success message in chat
+	 * </p>
+	 * @since 1.1.0
+	 */
+	private void handleHydrateResetCommand()
+	{
+		resetHydrateReminderTimeInterval();
+		final String resetString = "Hydrate reminder interval has been successfully reset";
+		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", resetString, null);
 	}
 
 	/**


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #29

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Add command handler for resetting the current hydrate reminder interval by making use of the existing `resetHydrateReminderTimeInterval` method.

After the reset is successful, a chat message is displayed to let the player know that the interval has been successfully reset.


## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.7

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![reset](https://user-images.githubusercontent.com/1442227/118064382-bd9e7980-b34f-11eb-9fac-7a49d11c70d2.gif)
