### PR TITLE
Add help command

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -1,13 +1,36 @@
 package com.hydratereminder;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * <p>All command arguments that the Hydrate Reminder plugin supports
  * </p>
  * @author jmakhack
  */
+@Getter
+@AllArgsConstructor
 public enum HydrateReminderCommandArgs
 {
-    NEXT,
-    PREV,
-    RESET;
+    NEXT("next"),
+    PREV("prev"),
+    RESET("reset"),
+    HELP("help");
+
+    /**
+     * Command argument name
+     */
+    private final String commandArg;
+
+    /**
+     * <p>Get the command argument name as a String
+     * </p>
+     * @return command argument name
+     * @since 1.1.0
+     */
+    @Override
+    public String toString()
+    {
+        return getCommandArg();
+    }
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -1,0 +1,13 @@
+package com.hydratereminder;
+
+/**
+ * <p>All command arguments that the Hydrate Reminder plugin supports
+ * </p>
+ * @author jmakhack
+ */
+public enum HydrateReminderCommandArgs
+{
+    NEXT,
+    PREV,
+    RESET;
+}

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -141,8 +141,13 @@ public class HydrateReminderPlugin extends Plugin
 						case RESET:
 							handleHydrateResetCommand();
 							break;
+						case HELP:
+							handleHydrateHelpCommand();
+							break;
 					}
-				} catch (IllegalArgumentException e) {
+				}
+				catch (IllegalArgumentException e)
+				{
 					log.warn(String.format("%s is not a supported argument for the %s command",
 							args[0], HYDRATE_COMMAND_NAME));
 				}
@@ -196,6 +201,27 @@ public class HydrateReminderPlugin extends Plugin
 		resetHydrateReminderTimeInterval();
 		final String resetString = "Hydrate reminder interval has been successfully reset";
 		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", resetString, null);
+	}
+
+	/**
+	 * <p>Handle the hydrate help command by displaying all available command arguments
+	 * </p>
+	 * @since 1.1.0
+	 */
+	private void handleHydrateHelpCommand()
+	{
+		final StringBuilder commandList = new StringBuilder();
+		final String listSeparator = ", ";
+		for (HydrateReminderCommandArgs arg : HydrateReminderCommandArgs.values())
+		{
+			if (commandList.length() > 0)
+			{
+				commandList.append(listSeparator);
+			}
+			commandList.append(arg.toString());
+		}
+		final String helpString = String.format("Available commands: ::%s %s", HYDRATE_COMMAND_NAME, commandList);
+		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", helpString, null);
 	}
 
 	/**

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -122,20 +122,23 @@ public class HydrateReminderPlugin extends Plugin
 			final String[] args = commandExecuted.getArguments();
 			if (ArrayUtils.isNotEmpty(args))
 			{
-				switch (args[0].toLowerCase())
+				try
 				{
-					case "next":
-						handleHydrateNextCommand();
-						break;
-					case "prev":
-						handleHydratePrevCommand();
-						break;
-					case "reset":
-						handleHydrateResetCommand();
-						break;
-					default:
-						log.warn(String.format("%s is not a supported argument for the hydrate command", args[0]));
-						break;
+					final HydrateReminderCommandArgs arg = HydrateReminderCommandArgs.valueOf(args[0].toUpperCase());
+					switch (arg)
+					{
+						case NEXT:
+							handleHydrateNextCommand();
+							break;
+						case PREV:
+							handleHydratePrevCommand();
+							break;
+						case RESET:
+							handleHydrateResetCommand();
+							break;
+					}
+				} catch (IllegalArgumentException e) {
+					log.warn(String.format("%s is not a supported argument for the hydrate command", args[0]));
 				}
 			}
 		}

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -57,6 +57,11 @@ public class HydrateReminderPlugin extends Plugin
 	private static final String HYDRATE_REMINDER_USERNAME = "HydrateReminder";
 
 	/**
+	 * Main command name for the Hydrate Reminder plugin
+	 */
+	private static final String HYDRATE_COMMAND_NAME = "hydrate";
+
+	/**
 	 * RuneLite client object
 	 */
 	@Inject
@@ -117,7 +122,7 @@ public class HydrateReminderPlugin extends Plugin
 	@Subscribe
 	public void onCommandExecuted(CommandExecuted commandExecuted)
     {
-		if (commandExecuted.getCommand().equalsIgnoreCase("hydrate"))
+		if (commandExecuted.getCommand().equalsIgnoreCase(HYDRATE_COMMAND_NAME))
 		{
 			final String[] args = commandExecuted.getArguments();
 			if (ArrayUtils.isNotEmpty(args))
@@ -138,7 +143,8 @@ public class HydrateReminderPlugin extends Plugin
 							break;
 					}
 				} catch (IllegalArgumentException e) {
-					log.warn(String.format("%s is not a supported argument for the hydrate command", args[0]));
+					log.warn(String.format("%s is not a supported argument for the %s command",
+							args[0], HYDRATE_COMMAND_NAME));
 				}
 			}
 		}

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -57,6 +57,11 @@ public class HydrateReminderPlugin extends Plugin
 	private static final String HYDRATE_REMINDER_USERNAME = "HydrateReminder";
 
 	/**
+	 * Prefix for all chat commands in RuneLite
+	 */
+	private static final String RUNELITE_COMMAND_PREFIX = "::";
+
+	/**
 	 * Main command name for the Hydrate Reminder plugin
 	 */
 	private static final String HYDRATE_COMMAND_NAME = "hydrate";
@@ -148,8 +153,10 @@ public class HydrateReminderPlugin extends Plugin
 				}
 				catch (IllegalArgumentException e)
 				{
-					log.warn(String.format("%s is not a supported argument for the %s command",
-							args[0], HYDRATE_COMMAND_NAME));
+					final String invalidArgString = String.format("%s%s %s is not a valid command",
+							RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_NAME, args[0]);
+					client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", invalidArgString, null);
+					handleHydrateHelpCommand();
 				}
 			}
 		}
@@ -220,7 +227,8 @@ public class HydrateReminderPlugin extends Plugin
 			}
 			commandList.append(arg.toString());
 		}
-		final String helpString = String.format("Available commands: ::%s %s", HYDRATE_COMMAND_NAME, commandList);
+		final String helpString = String.format("Available commands: %s%s %s",
+				RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_NAME, commandList);
 		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", helpString, null);
 	}
 


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #32

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Shows all available hydrate commands when `::hydrate help` is executed.

If the player inputs an invalid command such as `::hydrate xyz`, an error message is displayed in chat followed by the help message showing all the available hydrate commands.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.7

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-05-12 at 9 17 50 PM](https://user-images.githubusercontent.com/1442227/118076686-8b007b00-b367-11eb-9b4c-ad31364f188b.png)