### PR TITLE
Add hydrate welcome message

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderConfig.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderConfig.java
@@ -39,7 +39,7 @@ public interface HydrateReminderConfig extends Config
 	)
 	@ConfigItem(
 		keyName = "hydrateReminderInterval",
-		name = "Hydrate Interval",
+		name = "Hydrate interval",
 		description = "The time interval between each hydrate reminder",
 		position = 1
 	)
@@ -96,6 +96,23 @@ public interface HydrateReminderConfig extends Config
 		position = 4
 	)
 	default boolean hydrateReminderComputerNotificationEnabled()
+	{
+		return true;
+	}
+
+	/**
+	 * <p>Allows the player to enable/disable the hydrate login welcome message
+	 * </p>
+	 * @return true if the welcome message is to be enabled
+	 * @since 1.1.0
+	 */
+	@ConfigItem(
+			keyName = "hydrateReminderWelcomeMessageEnabled",
+			name = "Welcome message",
+			description = "Sets whether or not the welcome message should be displayed",
+			position = 5
+	)
+	default boolean hydrateReminderWelcomeMessageEnabled()
 	{
 		return true;
 	}

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -123,7 +123,8 @@ public class HydrateReminderPlugin extends Plugin
 	}
 
 	/**
-	 * <p>Detects when the player logs in and then starts the Hydrate Reminder interval
+	 * <p>Detects when the player logs in and then starts the Hydrate Reminder interval and
+	 * displays the hydrate welcome message
 	 * </p>
 	 * @param gameStateChanged the change game state event
 	 * @since 1.0.0
@@ -135,12 +136,17 @@ public class HydrateReminderPlugin extends Plugin
 		{
 			resetHydrateReminderTimeInterval();
 			log.debug("Hydrate Reminder plugin interval timer started");
-			new Timer().schedule(new TimerTask() {
-				@Override
-				public void run() {
-					sendHydrateWelcomeChatMessage();
-				}
-			}, 500L);
+			if (config.hydrateReminderWelcomeMessageEnabled())
+			{
+				new Timer().schedule(new TimerTask()
+				{
+					@Override
+					public void run()
+					{
+						sendHydrateWelcomeChatMessage();
+					}
+				}, 500L);
+			}
 		}
 	}
 

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang3.ArrayUtils;
 public class HydrateReminderPlugin extends Plugin
 {
 	/**
-	 * Hydrate Reminder text to display
+	 * Hydrate Reminder interval break text to display
 	 */
 	private static final List<String> HYDRATE_BREAK_TEXT_LIST =
 			Collections.unmodifiableList(
@@ -49,6 +49,26 @@ public class HydrateReminderPlugin extends Plugin
 						add("Drink water!");
 						add("Drink water to stay healthy");
 						add("Hey you, drink some water");
+					}});
+
+	/**
+	 * Hydrate Reminder startup welcome text to display
+	 */
+	private static final List<String> HYDRATE_WELCOME_TEXT_LIST =
+			Collections.unmodifiableList(
+					new ArrayList<String>() {{
+						add("Don't forget to stay hydrated.");
+						add("Type \"::hydrate help\" in chat to view available commands.");
+						add("Stay cool. Stay awesome. Stay hydrated.");
+						add("Keep calm and stay hydrated.");
+						add("Cheers to staying hydrated!");
+						add("Keep the geyser titans happy by staying hydrated.");
+						add("Hydration is love. Hydration is life.");
+						add("Out of water? Cast humidify to stay hydrated.");
+						add("It costs zero water runes to stay hydrated.");
+						add("Check out the hydrate commands by typing \"::hydrate help\" in chat.");
+						add("A hydrated adventurer is an unstoppable adventurer.");
+						add("It's dangerous to go alone. Stay hydrated!");
 					}});
 
 	/**
@@ -115,7 +135,26 @@ public class HydrateReminderPlugin extends Plugin
 		{
 			resetHydrateReminderTimeInterval();
 			log.debug("Hydrate Reminder plugin interval timer started");
+			new Timer().schedule(new TimerTask() {
+				@Override
+				public void run() {
+					sendHydrateWelcomeChatMessage();
+				}
+			}, 500L);
 		}
+	}
+
+	/**
+	 * <p>Sends a random hydrate welcome message in chat
+	 * </p>
+	 * @since 1.1.0
+	 */
+	private void sendHydrateWelcomeChatMessage()
+	{
+		Random randomGenerator = new Random();
+		String hydrateWelcomeMessage = HYDRATE_WELCOME_TEXT_LIST.get(
+				randomGenerator.nextInt(HYDRATE_WELCOME_TEXT_LIST.size()));
+		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", hydrateWelcomeMessage, null);
 	}
 
 	/**
@@ -149,6 +188,8 @@ public class HydrateReminderPlugin extends Plugin
 						case HELP:
 							handleHydrateHelpCommand();
 							break;
+						default:
+							throw new IllegalArgumentException();
 					}
 				}
 				catch (IllegalArgumentException e)
@@ -300,7 +341,6 @@ public class HydrateReminderPlugin extends Plugin
 	 */
 	private String getHydrateReminderMessage()
 	{
-
 		Random randomGenerator = new Random();
 		final String playerName = Objects.requireNonNull(client.getLocalPlayer()).getName();
 		String hydrateReminderMessage = HYDRATE_BREAK_TEXT_LIST.get(


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #31

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added 12 different welcome messages that display as a chat message on player login.\
Two of the 12 messages inform the player of the existence of hydrate chat commands.\
A 500ms delay is added to the posting of the message so that the official OSRS welcome message always gets displayed first in the chat window.

Added a toggle-able configuration setting for the welcome message that is enabled by default.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.7

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-05-13 at 2 16 31 AM](https://user-images.githubusercontent.com/1442227/118105517-543f5a80-b391-11eb-8040-7924db5a8237.png)
