### PR TITLE
Fix welcome message duplication issue

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -139,6 +139,12 @@ public class HydrateReminderPlugin extends Plugin
 	private int hydrateEmojiId = -1;
 
 	/**
+	 * True when game tick is the first one after login
+	 * Used to check if welcome message should be sent
+	 */
+	private Boolean isFirstGameTick = true;
+
+	/**
 	 * <p>Provides the configuration for the Hydrate Reminder plugin
 	 * </p>
 	 * @param configManager the plugin configuration manager
@@ -163,20 +169,10 @@ public class HydrateReminderPlugin extends Plugin
 	{
 		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
 		{
+			isFirstGameTick = true;
 			loadHydrateEmoji();
 			resetHydrateReminderTimeInterval();
 			log.debug("Hydrate Reminder plugin interval timer started");
-			if (config.hydrateReminderWelcomeMessageEnabled())
-			{
-				new Timer().schedule(new TimerTask()
-				{
-					@Override
-					public void run()
-					{
-						sendHydrateWelcomeChatMessage();
-					}
-				}, 500L);
-			}
 		}
 	}
 
@@ -347,6 +343,11 @@ public class HydrateReminderPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
+		if (isFirstGameTick && config.hydrateReminderWelcomeMessageEnabled())
+		{
+			sendHydrateWelcomeChatMessage();
+			isFirstGameTick = false;
+		}
 		final Instant nextHydrateReminderInstant = getNextHydrateReminderInstant();
 		if (nextHydrateReminderInstant.compareTo(Instant.now()) < 0)
 		{

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -237,6 +237,7 @@ public class HydrateReminderPluginTest
             times = 0;
         }};
         final Instant now = Instant.now();
+        setField(plugin, "isFirstGameTick", false);
         setField(plugin, "lastHydrateInstant", now);
         plugin.onGameTick(null);
         final Instant resetInstant = getField(plugin, "lastHydrateInstant");


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #40

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Instead of relying on using a timer to send the hydrate reminder welcome message after the usual OSRS welcome message, this solution sends the welcome message on the first game tick after each login.

Once the hydrate reminder welcome message is sent, a flag is set to false so that repeated welcome messages are not sent.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-07-09 at 12 53 58 AM](https://user-images.githubusercontent.com/1442227/125043801-2c4a3b80-e050-11eb-92b9-3c512485236b.png)
