### PR TITLE
Add a variety of hydrate reminder messages

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -72,11 +72,17 @@ public class HydrateReminderPlugin extends Plugin
 			Collections.unmodifiableList(
 					new ArrayList<String>() {{
 						add("It's time for a quick hydration break");
-						add("70% of the human brain is water so take a hydration break");
-						add("Dehydration causes fatigue, take a quick hydration break");
-						add("Drink water!");
-						add("Drink water to stay healthy");
-						add("Hey you, drink some water");
+						add("Dehydration causes fatigue so take a hydration break");
+						add("It's time to drink some good ol' water");
+						add("Stay healthy by taking a hydration break");
+						add("Time to glug, glug, glug some water");
+						add("It is now time to take a hydration break");
+						add("Time to hydrate");
+						add("Power up with a hydration break now");
+						add("Got water? It's time to hydrate");
+						add("Cheers to this hydration break");
+						add("Hydration time is now");
+						add("Fuel up with a hydration break");
 					}});
 
 	/**
@@ -410,7 +416,7 @@ public class HydrateReminderPlugin extends Plugin
 		final String playerName = Objects.requireNonNull(client.getLocalPlayer()).getName();
 		final String hydrateReminderMessage = HYDRATE_BREAK_TEXT_LIST.get(
 				randomGenerator.nextInt(HYDRATE_BREAK_TEXT_LIST.size()));
-		return String.format("%s, %s", hydrateReminderMessage, playerName);
+		return String.format("%s, %s.", hydrateReminderMessage, playerName);
 	}
 
 	/**

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -378,7 +378,7 @@ public class HydrateReminderPluginTest
         }};
         final List<String> hydrateMessageList = getField(plugin, "HYDRATE_BREAK_TEXT_LIST");
         final String message = invoke(plugin, "getHydrateReminderMessage");
-        assertTrue(hydrateMessageList.contains(message.replace(", OSRSplayer42", "")));
+        assertTrue(hydrateMessageList.contains(message.replace(", OSRSplayer42.", "")));
     }
 
     @Test


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #20 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added a variety of new messages for the hydrate reminder plugin to cycle through.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-07-10 at 12 51 27 AM](https://user-images.githubusercontent.com/1442227/125156179-06d53480-e119-11eb-83a5-38f8775746eb.png)
