### PR TITLE
Fix welcome message displaying during events issue

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -173,7 +173,7 @@ public class HydrateReminderPlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
-		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
+		if (gameStateChanged.getGameState() == GameState.LOGGING_IN)
 		{
 			isFirstGameTick = true;
 			loadHydrateEmoji();

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -45,12 +45,12 @@ public class HydrateReminderPluginTest
     }
 
     @Test
-    public void testOnGameStateChangedLogIn(@Mocked GameStateChanged gameStateChanged)
+    public void testOnGameStateChangedLoggingIn(@Mocked GameStateChanged gameStateChanged)
     {
         new Expectations()
         {{
             gameStateChanged.getGameState();
-            result = GameState.LOGGED_IN;
+            result = GameState.LOGGING_IN;
             times = 1;
         }};
         Instant now = getField(plugin, "lastHydrateInstant");
@@ -61,7 +61,7 @@ public class HydrateReminderPluginTest
     }
 
     @Test
-    public void testOnGameStateChangedNotLogIn(@Mocked GameStateChanged gameStateChanged)
+    public void testOnGameStateChangedNotLoggingIn(@Mocked GameStateChanged gameStateChanged)
     {
         new Expectations()
         {{


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #52
Closes #54 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Instead of checking for the LOGGED_IN state when doing the hydrate reminder initialization logic, the code now checks for the LOGGING_IN state. This is done because there are many instances where a player's state will change into the LOGGED_IN state such as going into and exiting a special event and also when hopping between worlds.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![ezgif-7-5ad52013a7c8](https://user-images.githubusercontent.com/1442227/125183951-0e571500-e1cf-11eb-90db-8dc4880a97bb.gif)
