### PR TITLE
[FIX] Hours, minutes, and seconds are always displayed as plural for next and prev commands

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -310,12 +310,12 @@ public class HydrateReminderPlugin extends Plugin
 	 * @return Time in a string format
 	 * @since 1.1.1
 	 */
-	String timeDisplay(int hours, int minutes, int seconds) {
+	public String timeDisplay(int hours, int minutes, int seconds) {
 		String hoursRepresentation = hours != 1 ? hours + " hours" : hours + " hour";
 		String minutesRepresentation = minutes != 1 ? minutes + " minutes" : minutes + " minute";
-		String secondesRepresentation = seconds != 1 ? seconds + " secondes" : seconds + " second";
+		String secondsRepresentation = seconds != 1 ? seconds + " seconds" : seconds + " second";
 		String timeDisplayString = String.format("%s %s %s until the next hydrate break",
-				hoursRepresentation, minutesRepresentation, secondesRepresentation);
+				hoursRepresentation, minutesRepresentation, secondsRepresentation);
 		return timeDisplayString;
 	}
 

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -282,8 +282,7 @@ public class HydrateReminderPlugin extends Plugin
 		final int hours = Math.toIntExact(timeUntilNextBreak.toHours());
 		final int minutes = Math.toIntExact(timeUntilNextBreak.toMinutes() % 60);
 		final int seconds = Math.toIntExact((timeUntilNextBreak.toMillis() / 1000) % 60);
-		final String timeString = String.format("%s hours %s minutes %s seconds until the next hydrate break",
-				hours, minutes, seconds);
+		final String timeString = timeDisplay(hours, minutes, seconds);
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, timeString);
 	}
 
@@ -299,9 +298,25 @@ public class HydrateReminderPlugin extends Plugin
 		final int hours = Math.toIntExact(timeSinceLastBreak.toHours());
 		final int minutes = Math.toIntExact(timeSinceLastBreak.toMinutes() % 60);
 		final int seconds = Math.toIntExact((timeSinceLastBreak.toMillis() / 1000) % 60);
-		final String timeString = String.format("%s hours %s minutes %s seconds since the last hydrate break",
-				hours, minutes, seconds);
+		final String timeString = timeDisplay(hours, minutes, seconds);
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, timeString);
+	}
+
+	/**
+	 * <p>Handle the String formatting of the specified time.</p>
+	 * @param hours
+	 * @param minutes
+	 * @param seconds
+	 * @return Time in a string format
+	 * @since 1.1.1
+	 */
+	String timeDisplay(int hours, int minutes, int seconds) {
+		String hoursRepresentation = hours > 1 ? hours + " hours" : hours + " hour";
+		String minutesRepresentation = minutes > 1 ? minutes + " minutes" : minutes + " minute";
+		String secondesRepresentation = seconds > 1 ? seconds + " secondes" : seconds + " second";
+		String timeDisplayString = String.format("%s %s %s until the next hydrate break",
+				hoursRepresentation, minutesRepresentation, secondesRepresentation);
+		return timeDisplayString;
 	}
 
 	/**

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -311,9 +311,9 @@ public class HydrateReminderPlugin extends Plugin
 	 * @since 1.1.1
 	 */
 	String timeDisplay(int hours, int minutes, int seconds) {
-		String hoursRepresentation = hours == 1 ? hours + " hours" : hours + " hour";
-		String minutesRepresentation = minutes == 1 ? minutes + " minutes" : minutes + " minute";
-		String secondesRepresentation = seconds == 1 ? seconds + " secondes" : seconds + " second";
+		String hoursRepresentation = hours != 1 ? hours + " hours" : hours + " hour";
+		String minutesRepresentation = minutes != 1 ? minutes + " minutes" : minutes + " minute";
+		String secondesRepresentation = seconds != 1 ? seconds + " secondes" : seconds + " second";
 		String timeDisplayString = String.format("%s %s %s until the next hydrate break",
 				hoursRepresentation, minutesRepresentation, secondesRepresentation);
 		return timeDisplayString;

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -311,9 +311,9 @@ public class HydrateReminderPlugin extends Plugin
 	 * @since 1.1.1
 	 */
 	String timeDisplay(int hours, int minutes, int seconds) {
-		String hoursRepresentation = hours > 1 ? hours + " hours" : hours + " hour";
-		String minutesRepresentation = minutes > 1 ? minutes + " minutes" : minutes + " minute";
-		String secondesRepresentation = seconds > 1 ? seconds + " secondes" : seconds + " second";
+		String hoursRepresentation = hours == 1 ? hours + " hours" : hours + " hour";
+		String minutesRepresentation = minutes == 1 ? minutes + " minutes" : minutes + " minute";
+		String secondesRepresentation = seconds == 1 ? seconds + " secondes" : seconds + " second";
 		String timeDisplayString = String.format("%s %s %s until the next hydrate break",
 				hoursRepresentation, minutesRepresentation, secondesRepresentation);
 		return timeDisplayString;

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -448,5 +448,6 @@ public class HydrateReminderPluginTest {
     public void shouldReturnCorrectStringFormatOfTheTime(){
         assertEquals("1 hour 1 minute 1 second until the next hydrate break", hydrateReminderPlugin.timeDisplay(1,1,1));
         assertEquals("19 hours 15 minutes 39 secondes until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
+        assertEquals("0 hours 15 minutes 39 secondes until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
     }
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -447,7 +447,7 @@ public class HydrateReminderPluginTest {
     @Test
     public void shouldReturnCorrectStringFormatOfTheTime(){
         assertEquals("1 hour 1 minute 1 second until the next hydrate break", hydrateReminderPlugin.timeDisplay(1,1,1));
-        assertEquals("19 hours 15 minutes 39 secondes until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
-        assertEquals("0 hours 15 minutes 39 secondes until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
+        assertEquals("19 hours 15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
+        assertEquals("0 hours 15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
     }
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -1,4 +1,9 @@
-//package com.hydratereminder;
+package com.hydratereminder;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
 //
 //import mockit.*;
 //import mockit.integration.junit4.JMockit;
@@ -436,3 +441,12 @@
 //        assertEquals(ChatMessageType.BROADCAST, messageType);
 //    }
 //}
+public class HydrateReminderPluginTest {
+    private final HydrateReminderPlugin hydrateReminderPlugin = new HydrateReminderPlugin();
+
+    @Test
+    public void shouldReturnCorrectStringFormatOfTheTime(){
+        assertEquals("1 hour 1 minute 1 second until the next hydrate break", hydrateReminderPlugin.timeDisplay(1,1,1));
+        assertEquals("19 hours 15 minutes 39 secondes until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
+    }
+}


### PR DESCRIPTION
## Associated Issue

Closes #67

## Implemented Solution
I added a method to take in charge the string formatting, and i used it in the methods that have the logic behind "::hydrate next" and "::hydrate  prev"

## Testing Details
By testing 3 cases: 1 , 0 and a different number than these two.
I couldn't test that in rs, as i don't play the game and i don't know how to set it up. 

