### PR TITLE
Remove unnecessary broadcast message spacing

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -465,10 +465,6 @@ public class HydrateReminderPlugin extends Plugin
 		final String hydrateEmoji = String.format("<img=%d>", hydrateEmojiId);
 		final StringBuilder hydrateMessage = new StringBuilder();
 		String sender = hydrateEmoji;
-		if (type == ChatMessageType.BROADCAST)
-		{
-			hydrateMessage.append(" ");
-		}
 		if (type != ChatMessageType.FRIENDSCHAT)
 		{
 			hydrateMessage.append(hydrateEmoji);


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #60

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Removed the unnecessary spacing at the start of broadcast messages from the hydrate reminder plugin.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-07-16 at 3 46 33 AM](https://user-images.githubusercontent.com/1442227/125938500-f820b239-7dfe-4008-b90f-0bc6f9501882.png)
