### PR TITLE
Changes time next/prev string to only display segments as needed

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -319,15 +319,13 @@ public class HydrateReminderPlugin extends Plugin
 			timeDisplayBuilder.append(hours != 1 ? hours + " hours " : hours + " hour ");
 		}
 
-		if(minutes > 0)
+		if(minutes > 0 || hours > 0)
 		{
 			timeDisplayBuilder.append(minutes != 1 ? minutes + " minutes " : minutes + " minute ");
 		}
 
-		if(seconds > 0)
-		{
-			timeDisplayBuilder.append(seconds != 1 ? seconds + " seconds " : seconds + " second ");
-		}
+		timeDisplayBuilder.append(seconds != 1 ? seconds + " seconds " : seconds + " second ");
+
 
 		timeDisplayBuilder.append("until the next hydrate break");
 

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -310,13 +310,28 @@ public class HydrateReminderPlugin extends Plugin
 	 * @return Time in a string format
 	 * @since 1.1.1
 	 */
-	public String timeDisplay(int hours, int minutes, int seconds) {
-		String hoursRepresentation = hours != 1 ? hours + " hours" : hours + " hour";
-		String minutesRepresentation = minutes != 1 ? minutes + " minutes" : minutes + " minute";
-		String secondsRepresentation = seconds != 1 ? seconds + " seconds" : seconds + " second";
-		String timeDisplayString = String.format("%s %s %s until the next hydrate break",
-				hoursRepresentation, minutesRepresentation, secondsRepresentation);
-		return timeDisplayString;
+	public String timeDisplay(int hours, int minutes, int seconds) 
+	{
+		StringBuilder timeDisplayBuilder = new StringBuilder();
+
+		if(hours > 0)
+		{
+			timeDisplayBuilder.append(hours != 1 ? hours + " hours " : hours + " hour ");
+		}
+
+		if(minutes > 0)
+		{
+			timeDisplayBuilder.append(minutes != 1 ? minutes + " minutes " : minutes + " minute ");
+		}
+
+		if(seconds > 0)
+		{
+			timeDisplayBuilder.append(seconds != 1 ? seconds + " seconds " : seconds + " second ");
+		}
+
+		timeDisplayBuilder.append("until the next hydrate break");
+
+		return timeDisplayBuilder.toString();
 	}
 
 	/**

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -448,6 +448,8 @@ public class HydrateReminderPluginTest {
     public void shouldReturnCorrectStringFormatOfTheTime(){
         assertEquals("1 hour 1 minute 1 second until the next hydrate break", hydrateReminderPlugin.timeDisplay(1,1,1));
         assertEquals("19 hours 15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
-        assertEquals("0 hours 15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
+        assertEquals("15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
+        assertEquals("1 hour 0 minutes 0 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(1, 0, 0));
+		assertEquals("0 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 0, 0));
     }
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -450,6 +450,6 @@ public class HydrateReminderPluginTest {
         assertEquals("19 hours 15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(19, 15, 39));
         assertEquals("15 minutes 39 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 15, 39));
         assertEquals("1 hour 0 minutes 0 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(1, 0, 0));
-		assertEquals("0 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 0, 0));
+	assertEquals("0 seconds until the next hydrate break", hydrateReminderPlugin.timeDisplay(0, 0, 0));
     }
 }


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #66

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
solved by using a string builder to append the segments as needed
## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Tested by inputting several different values into the time interval config field
Operating System: Windows 10 pro 20H2
RuneLite Version:  1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![image](https://user-images.githubusercontent.com/31221793/125961221-8c922f7f-abbf-4f1e-8041-bda6a1f5fb20.png)
