### PR TITLE
Fix emoji loading issue on plugin install

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -176,7 +176,6 @@ public class HydrateReminderPlugin extends Plugin
 		if (gameStateChanged.getGameState() == GameState.LOGGING_IN)
 		{
 			isFirstGameTick = true;
-			loadHydrateEmoji();
 			resetHydrateReminderTimeInterval();
 			log.debug("Hydrate Reminder plugin interval timer started");
 		}
@@ -374,6 +373,10 @@ public class HydrateReminderPlugin extends Plugin
 	{
 		if (isFirstGameTick && config.hydrateReminderWelcomeMessageEnabled())
 		{
+			if (hydrateEmojiId == -1)
+			{
+				loadHydrateEmoji();
+			}
 			sendHydrateWelcomeChatMessage();
 			isFirstGameTick = false;
 		}


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #58

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Move the logic for loading the hydrate emoji out from the LOGGING_IN state check and into the code that runs on the first game tick. This way the emoji will be loaded even if the LOGGING_IN state is never triggered.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
Note: This is just a screenshot to show that the normal functionality is still working. Unfortunately, the install functionality cannot be fully tested until after it is released on the plugin hub.
![Screen Shot 2021-07-19 at 12 33 04 AM](https://user-images.githubusercontent.com/1442227/126129365-f0886643-80fc-4dad-afab-90618a4f1d77.png)
