### PR TITLE
Fix wrong text display for prev command

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -278,11 +278,9 @@ public class HydrateReminderPlugin extends Plugin
 	{
 		final Instant nextHydrateReminderInstant = getNextHydrateReminderInstant();
 		final Duration timeUntilNextBreak = Duration.between(Instant.now(), nextHydrateReminderInstant);
-		final int hours = Math.toIntExact(timeUntilNextBreak.toHours());
-		final int minutes = Math.toIntExact(timeUntilNextBreak.toMinutes() % 60);
-		final int seconds = Math.toIntExact((timeUntilNextBreak.toMillis() / 1000) % 60);
-		final String timeString = getTimeDisplay(hours, minutes, seconds);
-		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, timeString);
+		final String timeString = getTimeDisplay(timeUntilNextBreak);
+		final String message = timeString + " until the next hydration break.";
+		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, message);
 	}
 
 	/**
@@ -294,35 +292,33 @@ public class HydrateReminderPlugin extends Plugin
 	private void handleHydratePrevCommand()
 	{
 		final Duration timeSinceLastBreak = Duration.between(lastHydrateInstant, Instant.now());
-		final int hours = Math.toIntExact(timeSinceLastBreak.toHours());
-		final int minutes = Math.toIntExact(timeSinceLastBreak.toMinutes() % 60);
-		final int seconds = Math.toIntExact((timeSinceLastBreak.toMillis() / 1000) % 60);
-		final String timeString = getTimeDisplay(hours, minutes, seconds);
-		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, timeString);
+		final String timeString = getTimeDisplay(timeSinceLastBreak);
+		final String message = timeString + " since the last hydration break.";
+		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, message);
 	}
 
 	/**
 	 * <p>Handle the String formatting of the specified time.
 	 * </p>
-	 * @param hours number of hours
-	 * @param minutes number of minutes
-	 * @param seconds number of seconds
-	 * @return Time in a string format
+	 * @param duration duration to extract time from
+	 * @return the time in string format
 	 * @since 1.1.1
 	 */
-	protected String getTimeDisplay(int hours, int minutes, int seconds)
+	protected String getTimeDisplay(Duration duration)
 	{
-		StringBuilder timeDisplayBuilder = new StringBuilder();
-		if(hours > 0)
+		final int hours = Math.toIntExact(duration.toHours());
+		final int minutes = Math.toIntExact(duration.toMinutes() % 60);
+		final int seconds = Math.toIntExact((duration.toMillis() / 1000) % 60);
+		final StringBuilder timeDisplayBuilder = new StringBuilder();
+		if (hours > 0)
 		{
 			timeDisplayBuilder.append(hours != 1 ? hours + " hours " : hours + " hour ");
 		}
-		if(minutes > 0 || hours > 0)
+		if (minutes > 0 || hours > 0)
 		{
 			timeDisplayBuilder.append(minutes != 1 ? minutes + " minutes " : minutes + " minute ");
 		}
-		timeDisplayBuilder.append(seconds != 1 ? seconds + " seconds " : seconds + " second ");
-		timeDisplayBuilder.append("until the next hydration break.");
+		timeDisplayBuilder.append(seconds != 1 ? seconds + " seconds" : seconds + " second");
 		return timeDisplayBuilder.toString();
 	}
 

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.time.Duration;
+
 //
 //import mockit.*;
 //import mockit.integration.junit4.JMockit;
@@ -445,16 +447,17 @@ public class HydrateReminderPluginTest {
     private final HydrateReminderPlugin hydrateReminderPlugin = new HydrateReminderPlugin();
 
     @Test
-    public void shouldReturnCorrectStringFormatOfTheTime(){
-        assertEquals("1 hour 1 minute 1 second until the next hydration break.",
-                hydrateReminderPlugin.getTimeDisplay(1,1,1));
-        assertEquals("19 hours 15 minutes 39 seconds until the next hydration break.",
-                hydrateReminderPlugin.getTimeDisplay(19, 15, 39));
-        assertEquals("15 minutes 39 seconds until the next hydration break.",
-                hydrateReminderPlugin.getTimeDisplay(0, 15, 39));
-        assertEquals("1 hour 0 minutes 0 seconds until the next hydration break.",
-                hydrateReminderPlugin.getTimeDisplay(1, 0, 0));
-        assertEquals("0 seconds until the next hydration break.",
-                hydrateReminderPlugin.getTimeDisplay(0, 0, 0));
+    public void shouldReturnCorrectStringFormatOfTheTime()
+    {
+        assertEquals("1 hour 1 minute 1 second",
+                hydrateReminderPlugin.getTimeDisplay(Duration.ofSeconds(3661)));
+        assertEquals("19 hours 15 minutes 39 seconds",
+                hydrateReminderPlugin.getTimeDisplay(Duration.ofSeconds(69339)));
+        assertEquals("15 minutes 39 seconds",
+                hydrateReminderPlugin.getTimeDisplay(Duration.ofSeconds(939)));
+        assertEquals("1 hour 0 minutes 0 seconds",
+                hydrateReminderPlugin.getTimeDisplay(Duration.ofHours(1)));
+        assertEquals("0 seconds",
+                hydrateReminderPlugin.getTimeDisplay(Duration.ofSeconds(0)));
     }
 }


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #76

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Change the `getTimeDisplay` helper method to only return the time part of the string instead of the full string. As a result, the methods that handle the prev and next commands can append the correct text to the end of the time display as needed.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.15

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-07-19 at 3 55 19 AM](https://user-images.githubusercontent.com/1442227/126150785-0f6e27c1-bf50-41bf-b92d-e68fd5fd7ec9.png)
