### PR TITLE
Added support for shortened commands.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.16'
+def runeLiteVersion = '1.7.18'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -28,6 +28,8 @@ package com.hydratereminder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>All command arguments that the Hydrate Reminder plugin supports
  * </p>
@@ -40,7 +42,11 @@ public enum HydrateReminderCommandArgs
     NEXT("next"),
     PREV("prev"),
     RESET("reset"),
-    HELP("help");
+    HELP("help"),
+    N("n"),
+    P("p"),
+    R("r"),
+    H("h");
 
     /**
      * Command argument name

--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -28,8 +28,6 @@ package com.hydratereminder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import javax.annotation.Nullable;
-
 /**
  * <p>All command arguments that the Hydrate Reminder plugin supports
  * </p>

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -114,6 +114,7 @@ public class HydrateReminderPlugin extends Plugin
 	 * Main command name for the Hydrate Reminder plugin
 	 */
 	private static final String HYDRATE_COMMAND_NAME = "hydrate";
+	private static final String HYDRATE_COMMAND_ALIAS = "hr";
 
 	/**
 	 * RuneLite client object
@@ -231,7 +232,8 @@ public class HydrateReminderPlugin extends Plugin
 	@Subscribe
 	public void onCommandExecuted(CommandExecuted commandExecuted)
     {
-		if (commandExecuted.getCommand().equalsIgnoreCase(HYDRATE_COMMAND_NAME))
+    	final String command = commandExecuted.getCommand();
+		if (command.equalsIgnoreCase(HYDRATE_COMMAND_NAME) || command.equalsIgnoreCase(HYDRATE_COMMAND_ALIAS))
 		{
 			final String[] args = commandExecuted.getArguments();
 			if (ArrayUtils.isNotEmpty(args))
@@ -242,15 +244,19 @@ public class HydrateReminderPlugin extends Plugin
 					switch (arg)
 					{
 						case NEXT:
+						case N:
 							handleHydrateNextCommand();
 							break;
 						case PREV:
+						case P:
 							handleHydratePrevCommand();
 							break;
 						case RESET:
+						case R:
 							handleHydrateResetCommand();
 							break;
 						case HELP:
+						case H:
 							handleHydrateHelpCommand();
 							break;
 						default:
@@ -352,8 +358,8 @@ public class HydrateReminderPlugin extends Plugin
 			}
 			commandList.append(arg.toString());
 		}
-		final String helpString = String.format("Available commands: %s%s %s",
-				RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_NAME, commandList);
+		final String helpString = String.format("Available commands: %s%s or ::%s %s",
+				RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_NAME, HYDRATE_COMMAND_ALIAS, commandList);
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, helpString);
 	}
 


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #84

## Implemented Solution
Added shortened commands to the `HydrateReminderCommandArgs` enum.
Updated the switch statement in the `onCommandExecuted`  method of the `HydrateReminderPlugin` class.

## Testing Details
<!---

-->
Passed all tests, and works as expected in game.

Operating System: Windows 10
RuneLite Version: 1.7.18

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
Using the `::hr n` command in game

![using_command](https://user-images.githubusercontent.com/60860251/127755273-d9172687-7c05-4303-a291-85a233b97c58.png)
![after_using_command](https://user-images.githubusercontent.com/60860251/127755276-0f71cbdd-758b-4819-b87c-dd3bf28cf6e6.png)

