### PR TITLE
Total hydration breaks

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -41,10 +41,12 @@ public enum HydrateReminderCommandArgs
     PREV("prev"),
     RESET("reset"),
     HELP("help"),
+    TOTAL("total"),
     N("n"),
     P("p"),
     R("r"),
-    H("h");
+    H("h"),
+    T("t");
 
     /**
      * Command argument name

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -53,7 +53,7 @@ import org.apache.commons.lang3.ArrayUtils;
 /**
  * <p>The main plugin logic for the Hydrate Reminder plugin
  * </p>
- * <p>Please see the {@link net.runelite.client.plugins.Plugin} class for true identity
+ * <p>Please see the {@link Plugin} class for true identity
  * </p>
  * @author jmakhack
  */
@@ -133,6 +133,16 @@ public class HydrateReminderPlugin extends Plugin
 	 */
 	private static final String HYDRATE_COMMAND_NAME = "hydrate";
 	private static final String HYDRATE_COMMAND_ALIAS = "hr";
+
+	/**
+	 *  Number by which to increment the number of hydration breaks each time a break occurs
+	 */
+	private static final int HYDRATION_BREAK_INCREMENT = 1;
+
+	/**
+	 * Number of total hydration breaks for the current session
+	 */
+	private int currentSessionHydrationBreaks = 0;
 
 	/**
 	 * RuneLite client object
@@ -432,6 +442,7 @@ public class HydrateReminderPlugin extends Plugin
 		{
 			handleHydrateReminderDispatch();
 			resetHydrateReminderTimeInterval();
+			incrementCurrentSessionHydrationBreaks();
 		}
 	}
 
@@ -573,5 +584,36 @@ public class HydrateReminderPlugin extends Plugin
 				break;
 		}
 		return chatMessageType;
+	}
+
+	/**
+	 * <p>CurrentSessionHydrationBreaks is the number of hydration breaks that have occurred
+	 * during the current session. It has a default value of zero (0).
+	 * </p>
+	 * @return the number of hydration breaks taken during the current session
+	 * @since 1.2.0
+	 */
+	public int getCurrentSessionHydrationBreaks() {
+		return currentSessionHydrationBreaks;
+	}
+
+	/**
+	 * <p>CurrentSessionHydrationBreaks is the number of hydration breaks that have occurred
+	 * during the current session. It has a default value of zero (0).
+	 * </p>
+	 * @param numberOfBreaks the number of hydration breaks taken
+	 * @since 1.2.0
+	 */
+	public void setCurrentSessionHydrationBreaks(int numberOfBreaks) {
+		this.currentSessionHydrationBreaks = numberOfBreaks;
+	}
+
+	/**
+	 * <p>Calculates the number of hydration breaks taken during the current session
+	 * </p>
+	 * @since 1.2.0
+	 */
+	public void incrementCurrentSessionHydrationBreaks() {
+		setCurrentSessionHydrationBreaks(getCurrentSessionHydrationBreaks() + HYDRATION_BREAK_INCREMENT);
 	}
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -53,7 +53,7 @@ import org.apache.commons.lang3.ArrayUtils;
 /**
  * <p>The main plugin logic for the Hydrate Reminder plugin
  * </p>
- * <p>Please see the {@link Plugin} class for true identity
+ * <p>Please see the {@link net.runelite.client.plugins.Plugin} class for true identity
  * </p>
  * @author jmakhack
  */

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -289,6 +289,10 @@ public class HydrateReminderPlugin extends Plugin
 						case H:
 							handleHydrateHelpCommand();
 							break;
+						case TOTAL:
+						case T:
+							handleHydrateTotalCommand();
+							break;
 						default:
 							throw new IllegalArgumentException();
 					}
@@ -416,6 +420,18 @@ public class HydrateReminderPlugin extends Plugin
 		final String helpString = String.format("Available commands: %s%s or ::%s %s",
 				RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_NAME, HYDRATE_COMMAND_ALIAS, commandList);
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, helpString);
+	}
+
+	/**
+	 * <p>Handle the hydrate total command by displaying the overall number of hydration breaks taken
+	 * </p>
+	 * @since 1.2.0
+	 */
+	private void handleHydrateTotalCommand() {
+		// TO DO: Output the overall total number of hydration breaks across sessions
+		final String totalString = String.format("Current session: %d hydration breaks.",
+				getCurrentSessionHydrationBreaks());
+		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, totalString);
 	}
 
 	/**

--- a/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
@@ -12,9 +12,11 @@ public class HydrateReminderCommandArgsTest
         assertEquals("prev", HydrateReminderCommandArgs.PREV.toString());
         assertEquals("reset", HydrateReminderCommandArgs.RESET.toString());
         assertEquals("help", HydrateReminderCommandArgs.HELP.toString());
+        assertEquals("total", HydrateReminderCommandArgs.TOTAL.toString());
         assertEquals("n", HydrateReminderCommandArgs.N.toString());
         assertEquals("p", HydrateReminderCommandArgs.P.toString());
         assertEquals("r", HydrateReminderCommandArgs.R.toString());
         assertEquals("h", HydrateReminderCommandArgs.H.toString());
+        assertEquals("t", HydrateReminderCommandArgs.T.toString());
     }
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -3,6 +3,7 @@ package com.hydratereminder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -10,7 +11,25 @@ import java.util.Optional;
 
 public class HydrateReminderPluginTest {
 
-    private final HydrateReminderPlugin hydrateReminderPlugin = new HydrateReminderPlugin();
+    private HydrateReminderPlugin hydrateReminderPlugin;
+
+    @Before
+    public void setupHydrateReminderPlugin() {
+        hydrateReminderPlugin = new HydrateReminderPlugin();
+    }
+
+    @Test
+    public void init_ShouldReturnZeroHydrationBreaksForTheCurrentSession() {
+        assertEquals(0, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
+    }
+
+    @Test
+    public void shouldIncrementNumberOfHydrationBreaksForTheCurrentSession() {
+        hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
+        hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
+        hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
+        assertEquals(3, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
+    }
 
     @Test
     public void shouldReturnCorrectStringFormatOfTheTime()


### PR DESCRIPTION
## Associated Issue

References #88 

## Implemented Solution

Partially completes issue #88, implemented tracking of the number of hydration breaks over the duration of the current session only. This does not track the overall total number of hydration breaks across distinct game sessions.

Commands added: <code>::hydrate total</code> and <code>::hydrate t</code>, both to display a message indicating the number of hydration breaks taken.

Updated the <code>HydrateReminderCommandArgsTest</code> class to reflect the additional commands

Updated the unit tests in <code>HydrateReminderPluginTest</code> to validate correct functionality for the <code>incrementCurrentSessionHydrationBreaks</code> method which updates the number of breaks taken; also added a <code>@Before</code> method to instantiate a new <code>HydrateReminderPlugin</code> before each test.

## Testing Details

Implemented new unit tests / updated existing unit tests to validate correct functionality.
All tests pass and functions as expected in game.

Operating System: Windows 10
RuneLite Version:  1.7.18

## Screenshots

![hydrate_reminder_number_of_breaks](https://user-images.githubusercontent.com/37886407/127816242-c091adab-0df4-4500-85e8-35bc801c0f16.PNG)
First Session

![hydrate_reminder_number_of_breaks_second-session](https://user-images.githubusercontent.com/37886407/127816307-52ec5ed6-5c35-4174-8f2a-87459d48e444.PNG)
Second Session