### PR TITLE
Fix prev command to account for resets

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -354,13 +354,14 @@ public class HydrateReminderPlugin extends Plugin
 	 * @since 1.2.0
 	 */
 	protected String formatHandleHydratePrevCommand(Optional<Duration> timeSinceLastBreak) {
-		if (getCurrentResetState())
-		{
-			return getTimeDisplay(timeSinceLastBreak.get()) + " since the last hydration interval reset.";
-		}
 		if (timeSinceLastBreak.isPresent())
 		{
-			return getTimeDisplay(timeSinceLastBreak.get()) + " since the last hydration break.";
+			final String timeString = getTimeDisplay(timeSinceLastBreak.get());
+			if (getCurrentResetState())
+			{
+				return timeString + " since the last hydration interval reset.";
+			}
+			return timeString + " since the last hydration break.";
 		}
 		return "No hydration breaks have been taken yet.";
 	}
@@ -464,13 +465,16 @@ public class HydrateReminderPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		if (isFirstGameTick && config.hydrateReminderWelcomeMessageEnabled())
+		if (isFirstGameTick)
 		{
 			if (hydrateEmojiId == -1)
 			{
 				loadHydrateEmoji();
 			}
-			sendHydrateWelcomeChatMessage();
+			if (config.hydrateReminderWelcomeMessageEnabled())
+			{
+				sendHydrateWelcomeChatMessage();
+			}
 			isFirstGameTick = false;
 		}
 		final Instant nextHydrateReminderInstant = getNextHydrateReminderInstant();

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -167,7 +167,16 @@ public class HydrateReminderPlugin extends Plugin
 	 */
 	private Optional<Instant> lastHydrateInstant = Optional.empty();
 
+	/**
+	 * The instant at which the player logs in
+	 */
 	private Instant loginInstant;
+
+	/**
+	 * True when reset command has been triggered
+	 * Returns to false on next hydration break
+	 */
+	private Boolean hasBeenReset = false;
 
 	/**
 	 * The id of the hydrate emoji
@@ -207,6 +216,8 @@ public class HydrateReminderPlugin extends Plugin
 		if (gameStateChanged.getGameState() == GameState.LOGGING_IN)
 		{
 			isFirstGameTick = true;
+			setResetState(false);
+			lastHydrateInstant = Optional.empty();
 			this.loginInstant = Instant.now();
 			log.debug("Hydrate Reminder plugin interval timer started");
 		}
@@ -343,7 +354,12 @@ public class HydrateReminderPlugin extends Plugin
 	 * @since 1.2.0
 	 */
 	protected String formatHandleHydratePrevCommand(Optional<Duration> timeSinceLastBreak) {
-		if(timeSinceLastBreak.isPresent()) {
+		if (getCurrentResetState())
+		{
+			return getTimeDisplay(timeSinceLastBreak.get()) + " since the last hydration interval reset.";
+		}
+		if (timeSinceLastBreak.isPresent())
+		{
 			return getTimeDisplay(timeSinceLastBreak.get()) + " since the last hydration break.";
 		}
 		return "No hydration breaks have been taken yet.";
@@ -356,7 +372,8 @@ public class HydrateReminderPlugin extends Plugin
 	 * @since 1.2.0
 	 */
 	protected Optional<Duration> getDurationSinceLastBreak(Optional<Instant> lastHydrateInstant) {
-		if(lastHydrateInstant.isPresent()) {
+		if (lastHydrateInstant.isPresent())
+		{
 			return Optional.of(Duration.between(lastHydrateInstant.get(), Instant.now()));
 		}
 		return Optional.empty();
@@ -396,6 +413,7 @@ public class HydrateReminderPlugin extends Plugin
 	private void handleHydrateResetCommand()
 	{
 		resetHydrateReminderTimeInterval();
+		setResetState(true);
 		final String resetString = "Hydrate reminder interval has been successfully reset.";
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, resetString);
 	}
@@ -458,6 +476,7 @@ public class HydrateReminderPlugin extends Plugin
 		final Instant nextHydrateReminderInstant = getNextHydrateReminderInstant();
 		if (nextHydrateReminderInstant.compareTo(Instant.now()) < 0)
 		{
+			setResetState(false);
 			handleHydrateReminderDispatch();
 			resetHydrateReminderTimeInterval();
 			incrementCurrentSessionHydrationBreaks();
@@ -611,7 +630,8 @@ public class HydrateReminderPlugin extends Plugin
 	 * @return the number of hydration breaks taken during the current session
 	 * @since 1.2.0
 	 */
-	public int getCurrentSessionHydrationBreaks() {
+	public int getCurrentSessionHydrationBreaks()
+	{
 		return currentSessionHydrationBreaks;
 	}
 
@@ -622,7 +642,8 @@ public class HydrateReminderPlugin extends Plugin
 	 * @param numberOfBreaks the number of hydration breaks taken
 	 * @since 1.2.0
 	 */
-	public void setCurrentSessionHydrationBreaks(int numberOfBreaks) {
+	public void setCurrentSessionHydrationBreaks(int numberOfBreaks)
+	{
 		this.currentSessionHydrationBreaks = numberOfBreaks;
 	}
 
@@ -631,7 +652,32 @@ public class HydrateReminderPlugin extends Plugin
 	 * </p>
 	 * @since 1.2.0
 	 */
-	public void incrementCurrentSessionHydrationBreaks() {
+	public void incrementCurrentSessionHydrationBreaks()
+	{
 		setCurrentSessionHydrationBreaks(getCurrentSessionHydrationBreaks() + HYDRATION_BREAK_INCREMENT);
+	}
+
+	/**
+	 * <p>Gets the current reset state which is true if the hydration interval has been reset
+	 * and no breaks have occurred since then
+	 * </p>
+	 * @return true if hydration interval has just been reset, false otherwise
+	 * @since 1.2.0
+	 */
+	public Boolean getCurrentResetState()
+	{
+		return hasBeenReset;
+	}
+
+	/**
+	 * <p>Sets the current reset state which should be true if the hydration interval
+	 * has been reset and no breaks have occurred since then
+	 * </p>
+	 * @param state the reset state to set
+	 * @since 1.2.0
+	 */
+	public void setResetState(Boolean state)
+	{
+		hasBeenReset = state;
 	}
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -1,13 +1,12 @@
 package com.hydratereminder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Optional;
+
+import static org.junit.Assert.*;
 
 public class HydrateReminderPluginTest {
 
@@ -19,7 +18,7 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void init_ShouldReturnZeroHydrationBreaksForTheCurrentSession() {
+    public void initShouldReturnZeroHydrationBreaksForTheCurrentSession() {
         assertEquals(0, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
     }
 
@@ -29,6 +28,19 @@ public class HydrateReminderPluginTest {
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         assertEquals(3, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
+    }
+
+    @Test
+    public void initShouldSetTheCorrectResetState() {
+        assertFalse(hydrateReminderPlugin.getCurrentResetState());
+    }
+
+    @Test
+    public void shouldSetTheCorrectResetState() {
+        hydrateReminderPlugin.setResetState(true);
+        assertTrue(hydrateReminderPlugin.getCurrentResetState());
+        hydrateReminderPlugin.setResetState(false);
+        assertFalse(hydrateReminderPlugin.getCurrentResetState());
     }
 
     @Test


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #83 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
After a reset command is triggered, there is a reset flag that is set to true. Any following prev command uses will display the correct text indicating the amount of time that has passed since the reset occurred. When the next hydration break occurs, the reset flag is set back to false so the prev command will go back to displaying the amount of time since that break.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.18

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![Screen Shot 2021-08-03 at 1 39 26 AM](https://user-images.githubusercontent.com/1442227/128000015-6e5a0220-8504-4a76-97da-20706e8a83e8.png)
