### PR TITLE
Add hydrate reminder timer infobox to overlay

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderTimer.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderTimer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, jmakhack <https://github.com/jmakhack>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.hydratereminder;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.time.Duration;
+import java.time.Instant;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
+
+/**
+ * <p>The infobox that displays the time remaining until the next hydration break
+ * </p>
+ * <p>Please see the {@link net.runelite.client.ui.overlay.infobox.InfoBox} class for true identity
+ * </p>
+ * @author jmakhack
+ */
+@Getter
+@ToString
+public class HydrateReminderTimer extends InfoBox
+{
+    /**
+     * <p>The text color to display in the hydrate reminder infobox
+     * </p>
+     * @param textColor infobox text color
+     * @return infobox text color
+     */
+    @Getter
+    @Setter
+    private Color textColor;
+
+    /**
+     * Hydrate reminder plugin that created the timer
+     */
+    private HydrateReminderPlugin hydrateReminderPlugin;
+
+    /**
+     * <p>Main constructor to initialize a new hydrate reminder timer
+     * </p>
+     * @param plugin the plugin creating the timer
+     * @param image the background image for the infobox
+     * @since 1.2.0
+     */
+    HydrateReminderTimer(HydrateReminderPlugin plugin, BufferedImage image)
+    {
+        super(image, plugin);
+        setPriority(InfoBoxPriority.MED);
+        hydrateReminderPlugin = plugin;
+        textColor = Color.WHITE;
+    }
+
+    /**
+     * <p>Gets the current text that is displayed in the timer infobox
+     * </p>
+     * @return text displayed in timer infobox
+     * @since 1.2.0
+     */
+    @Override
+    public String getText()
+    {
+        final Instant endTime = hydrateReminderPlugin.getNextHydrateReminderInstant();
+        final Duration timeRemaining = Duration.between(Instant.now(), endTime);
+        final int seconds = (int) ((timeRemaining.toMillis() / 1000L) % 60);
+        final int minutes = (int) (timeRemaining.toMillis() / 60000L);
+        return String.format("%d:%02d", minutes > 0 ? minutes : 0, seconds > 0 ? seconds : 0);
+    }
+}

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -9,22 +9,26 @@ import java.util.Optional;
 
 import static org.junit.Assert.*;
 
-public class HydrateReminderPluginTest {
+public class HydrateReminderPluginTest
+{
 
     private HydrateReminderPlugin hydrateReminderPlugin;
 
     @Before
-    public void setupHydrateReminderPlugin() {
+    public void setupHydrateReminderPlugin()
+    {
         hydrateReminderPlugin = new HydrateReminderPlugin();
     }
 
     @Test
-    public void initShouldReturnZeroHydrationBreaksForTheCurrentSession() {
+    public void initShouldReturnZeroHydrationBreaksForTheCurrentSession()
+    {
         assertEquals(0, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
     }
 
     @Test
-    public void shouldIncrementNumberOfHydrationBreaksForTheCurrentSession() {
+    public void shouldIncrementNumberOfHydrationBreaksForTheCurrentSession()
+    {
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
@@ -32,12 +36,14 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void initShouldSetTheCorrectResetState() {
+    public void initShouldSetTheCorrectResetState()
+    {
         assertFalse(hydrateReminderPlugin.isResetState());
     }
 
     @Test
-    public void shouldSetTheCorrectResetState() {
+    public void shouldSetTheCorrectResetState()
+    {
         hydrateReminderPlugin.setResetState(true);
         assertTrue(hydrateReminderPlugin.isResetState());
         hydrateReminderPlugin.setResetState(false);
@@ -60,14 +66,16 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldReturnDifferentMessageWhenThereIsNoTimeSinceLastBreak() {
+    public void shouldReturnDifferentMessageWhenThereIsNoTimeSinceLastBreak()
+    {
         final Optional<Duration> timeSinceLastBreak = Optional.empty();
         final String prevCommandMessage = hydrateReminderPlugin.formatHandleHydratePrevCommand(timeSinceLastBreak);
         assertEquals("No hydration breaks have been taken yet.", prevCommandMessage);
     }
 
     @Test
-    public void shouldReturnDifferentMessageWhenThereIsResetSinceLastBreak() {
+    public void shouldReturnDifferentMessageWhenThereIsResetSinceLastBreak()
+    {
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofSeconds(645));
         hydrateReminderPlugin.setResetState(true);
         final String prevCommandMessage = hydrateReminderPlugin.formatHandleHydratePrevCommand(timeSinceLastBreak);
@@ -75,27 +83,31 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldReturnNoDurationWhenThereIsNoLastBreak() {
+    public void shouldReturnNoDurationWhenThereIsNoLastBreak()
+    {
         final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(Optional.empty());
         assertFalse(timeSinceLastBreak.isPresent());
     }
 
     @Test
-    public void shouldReturnDurationWhenThereIsLastBreak() {
+    public void shouldReturnDurationWhenThereIsLastBreak()
+    {
         final Optional<Instant> timeOfLastBreak = Optional.of(Instant.now());
         final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(timeOfLastBreak);
         assertTrue(timeSinceLastBreak.isPresent());
     }
 
     @Test
-    public void shouldReturnCorrectStringFormatOfHandleHydratePrevCommandMessage() {
+    public void shouldReturnCorrectStringFormatOfHandleHydratePrevCommandMessage()
+    {
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofMinutes(130));
         final String prevCommandMessage = hydrateReminderPlugin.formatHandleHydratePrevCommand(timeSinceLastBreak);
         assertEquals("2 hours 10 minutes 0 seconds since the last hydration break.", prevCommandMessage);
     }
 
     @Test
-    public void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred() {
+    public void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred()
+    {
         assertFalse(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
         hydrateReminderPlugin.resetHydrateReminderTimeInterval();
         assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #65

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Created a new HydrateReminderTimer class which extends from the InfoBox class. This new class creates the new infobox to display on the overlay with the countdown timer based on when the next hydrate break is to occur. Whenever a player logs in, the timer is created and rendered onto the upper left overlay.

Note: Unit tests to be added in a separate issue. 

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Big Sur
RuneLite Version: 1.7.22

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
![hydrate-timer](https://user-images.githubusercontent.com/1442227/133163447-a16fb707-555d-4e99-ae00-ccb00a76a9aa.gif)
