### PR TITLE
fix: combine enum constants as aliases

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -37,21 +37,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HydrateReminderCommandArgs
 {
-    NEXT("next"),
-    PREV("prev"),
-    RESET("reset"),
-    HELP("help"),
-    TOTAL("total"),
-    N("n"),
-    P("p"),
-    R("r"),
-    H("h"),
-    T("t");
+    NEXT("next", "n"),
+    PREV("prev", "p"),
+    RESET("reset", "r"),
+    HELP("help", "h"),
+    TOTAL("total", "t");
 
     /**
      * Command argument name
      */
     private final String commandArg;
+    private final String commandArgAbbr;
 
     /**
      * <p>Get the command argument name as a String

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -355,23 +355,18 @@ public class HydrateReminderPlugin extends Plugin
 					switch (arg)
 					{
 						case NEXT:
-						case N:
 							handleHydrateNextCommand();
 							break;
 						case PREV:
-						case P:
 							handleHydratePrevCommand();
 							break;
 						case RESET:
-						case R:
 							handleHydrateResetCommand();
 							break;
 						case HELP:
-						case H:
 							handleHydrateHelpCommand();
 							break;
 						case TOTAL:
-						case T:
 							handleHydrateTotalCommand();
 							break;
 						default:

--- a/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
@@ -13,10 +13,21 @@ public class HydrateReminderCommandArgsTest
         assertEquals("reset", HydrateReminderCommandArgs.RESET.toString());
         assertEquals("help", HydrateReminderCommandArgs.HELP.toString());
         assertEquals("total", HydrateReminderCommandArgs.TOTAL.toString());
-        assertEquals("n", HydrateReminderCommandArgs.N.toString());
-        assertEquals("p", HydrateReminderCommandArgs.P.toString());
-        assertEquals("r", HydrateReminderCommandArgs.R.toString());
-        assertEquals("h", HydrateReminderCommandArgs.H.toString());
-        assertEquals("t", HydrateReminderCommandArgs.T.toString());
+    }
+
+    @Test
+    public void testAliases()
+    {
+        assertEquals("next", HydrateReminderCommandArgs.NEXT.getCommandArg());
+        assertEquals("prev", HydrateReminderCommandArgs.PREV.getCommandArg());
+        assertEquals("reset", HydrateReminderCommandArgs.RESET.getCommandArg());
+        assertEquals("help", HydrateReminderCommandArgs.HELP.getCommandArg());
+        assertEquals("total", HydrateReminderCommandArgs.TOTAL.getCommandArg());
+
+        assertEquals("n", HydrateReminderCommandArgs.NEXT.getCommandArgAbbr());
+        assertEquals("p", HydrateReminderCommandArgs.PREV.getCommandArgAbbr());
+        assertEquals("r", HydrateReminderCommandArgs.RESET.getCommandArgAbbr());
+        assertEquals("h", HydrateReminderCommandArgs.HELP.getCommandArgAbbr());
+        assertEquals("t", HydrateReminderCommandArgs.TOTAL.getCommandArgAbbr());
     }
 }


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #113 

## Implemented Solution
- Updated all enum values in `HydrateReminderCommandArgs` to contain their respective aliases
- Ensured that the `toString()` method has not changed in functionality
- Updated the unit test in `src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java`

<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->

## Testing Details
Implemented new unit tests / updated existing unit tests to validate correct functionality.
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
<!---
Operating System: 
RuneLite Version: 

## Screenshots
-->
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
