### PR TITLE
fix: fetch enum by alias

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -60,4 +60,14 @@ public enum HydrateReminderCommandArgs
     {
         return getCommandArg();
     }
+
+    public static HydrateReminderCommandArgs getValue(String command)
+    {
+        for (HydrateReminderCommandArgs enumValue : HydrateReminderCommandArgs.values())
+        {
+            if (enumValue.getCommandArg() == command || enumValue.getCommandArgAbbr() == command)
+                return enumValue;
+        }
+        throw new IllegalArgumentException();
+    }
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -351,7 +351,7 @@ public class HydrateReminderPlugin extends Plugin
 			{
 				try
 				{
-					final HydrateReminderCommandArgs arg = HydrateReminderCommandArgs.valueOf(args[0].toUpperCase());
+					final HydrateReminderCommandArgs arg = HydrateReminderCommandArgs.getValue(args[0].toLowerCase());
 					switch (arg)
 					{
 						case NEXT:

--- a/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
@@ -30,4 +30,32 @@ public class HydrateReminderCommandArgsTest
         assertEquals("h", HydrateReminderCommandArgs.HELP.getCommandArgAbbr());
         assertEquals("t", HydrateReminderCommandArgs.TOTAL.getCommandArgAbbr());
     }
+
+    @Test
+    public void testGetValue()
+    {
+        assertEquals(HydrateReminderCommandArgs.NEXT, HydrateReminderCommandArgs.getValue("next"));
+        assertEquals(HydrateReminderCommandArgs.PREV, HydrateReminderCommandArgs.getValue("prev"));
+        assertEquals(HydrateReminderCommandArgs.RESET, HydrateReminderCommandArgs.getValue("reset"));
+        assertEquals(HydrateReminderCommandArgs.HELP, HydrateReminderCommandArgs.getValue("help"));
+        assertEquals(HydrateReminderCommandArgs.TOTAL, HydrateReminderCommandArgs.getValue("total"));
+
+        assertEquals(HydrateReminderCommandArgs.NEXT, HydrateReminderCommandArgs.getValue("n"));
+        assertEquals(HydrateReminderCommandArgs.PREV, HydrateReminderCommandArgs.getValue("p"));
+        assertEquals(HydrateReminderCommandArgs.RESET, HydrateReminderCommandArgs.getValue("r"));
+        assertEquals(HydrateReminderCommandArgs.HELP, HydrateReminderCommandArgs.getValue("h"));
+        assertEquals(HydrateReminderCommandArgs.TOTAL, HydrateReminderCommandArgs.getValue("t"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetValue_throwsIfNullCommand()
+    {
+        HydrateReminderCommandArgs.getValue(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetValue_throwsIfInvalidCommand()
+    {
+        HydrateReminderCommandArgs.getValue("dummy");
+    }
 }


### PR DESCRIPTION
## Associated Issue
Closes #122 

## Implemented Solution
Added function `HydrateReminderCommandArgs.getValue` that takes a string input and returns the corresponding enum if the input command matches any of the enum values/aliases. Throws an `IllegalArgumentException` otherwise.

## Testing Details
Implemented new unit tests / updated existing unit tests to validate correct functionality.
