### PR TITLE
Test getDurationSinceLastBreak returns correct duration

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -394,7 +394,7 @@ public class HydrateReminderPlugin extends Plugin
 	 */
 	private void handleHydratePrevCommand()
 	{
-		final Optional<Duration> timeSinceLastBreak = getDurationSinceLastBreak(getLastHydrateInstant());
+		final Optional<Duration> timeSinceLastBreak = getDurationSinceLastBreak(getLastHydrateInstant(), Instant.now());
 		final String message = formatHandleHydratePrevCommand(timeSinceLastBreak);
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, message);
 	}
@@ -424,12 +424,13 @@ public class HydrateReminderPlugin extends Plugin
 	 * <p>Calculate the duration since the last break
 	 * </p>
 	 * @param lastHydrateInstant Optional Instant representing the lastHydrateInstant if it exists.
+	 * @param currentInstant Instant representing the current instant in time.
 	 * @return Optional Duration representing duration from last break till now, if not it is empty.
 	 * @since 1.2.0
 	 */
-	protected Optional<Duration> getDurationSinceLastBreak(Optional<Instant> lastHydrateInstant)
+	protected Optional<Duration> getDurationSinceLastBreak(Optional<Instant> lastHydrateInstant,Instant currentInstant)
 	{
-		return lastHydrateInstant.map(instant -> Duration.between(instant, Instant.now()));
+		return lastHydrateInstant.map(instant -> Duration.between(instant, currentInstant));
 	}
 
 	/**

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -3,8 +3,11 @@ package com.hydratereminder;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
@@ -84,7 +87,7 @@ public class HydrateReminderPluginTest
     @Test
     public void shouldReturnNoDurationWhenThereIsNoLastBreak()
     {
-        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(Optional.empty());
+        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(Optional.empty(), Instant.now());
         assertFalse(timeSinceLastBreak.isPresent());
     }
 
@@ -92,7 +95,7 @@ public class HydrateReminderPluginTest
     public void shouldReturnDurationWhenThereIsLastBreak()
     {
         final Optional<Instant> timeOfLastBreak = Optional.of(Instant.now());
-        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(timeOfLastBreak);
+        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(timeOfLastBreak, Instant.now());
         assertTrue(timeSinceLastBreak.isPresent());
     }
 
@@ -112,11 +115,17 @@ public class HydrateReminderPluginTest
         assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
     }
 
-//    TODO: Need a static clock in hydrateReminderPlugin so i can mock it in the test to override Instant.now(Clock)
-//    @Test
-//    public void shoudldGetCorrectDurationFromLastBreakTillNowWhenThereIsLastBreak()
-//    {
-//        final Instant lastBreakInstant = Instant.now(Clock.fixed())
-//        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak();
-//    }
+    @Test
+    public void shoudldGetCorrectDurationFromLastBreakTillNowWhenThereIsLastBreak()
+    {
+        Instant nowInstant = Instant.now();
+        Instant lastBreakInstant = nowInstant.minus(1, ChronoUnit.HOURS);
+
+        Duration expectedDuration = Duration.ofHours(1);
+
+        final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(Optional.of(lastBreakInstant), nowInstant);
+
+        assertEquals(expectedDuration, timeSinceLastBreak.get());
+
+    }
 }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -3,10 +3,8 @@ package com.hydratereminder;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 


### PR DESCRIPTION
## Associated Issue
Closes #139

## Implemented Solution
This commit had the purpose to uncomment an existing test that would check if the method getDurationSinceLastBreak from the HydrateReminderPlugin class would return the correct duration.

To make this test work, I added a second parameter to the method which represents the current Instant. This way it was possible in the test to mock two instants so that they would always have a duration of 1 hour between them.

Due to the change in the method parameters, the code where this method was used was refactored to reflect this changes without changing how the code worked previously
