### PR TITLE
Ticket issue 145 add hydrate command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .project
 .settings/
 
+bin
 build
 nbactions.xml
 nb-configuration.xml

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.24.3'
+def runeLiteVersion = '1.8.27'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderCommandArgs.java
@@ -42,6 +42,7 @@ public enum HydrateReminderCommandArgs
     NEXT("next", "n"),
     PREV("prev", "p"),
     RESET("reset", "r"),
+    HYDRATE("hydrate","hr"),
     HELP("help", "h"),
     TOTAL("total", "t");
 

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -351,6 +351,8 @@ public class HydrateReminderPlugin extends Plugin
 						case RESET:
 							handleHydrateResetCommand();
 							break;
+						case HYDRATE:
+							break;
 						case HELP:
 							handleHydrateHelpCommand();
 							break;
@@ -471,6 +473,20 @@ public class HydrateReminderPlugin extends Plugin
 		setResetState(true);
 		final String resetString = "Hydrate reminder interval has been successfully reset.";
 		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, resetString);
+	}
+
+	/**
+	 * <p>Handle the hydrate "hydrate" command by resetting the current hydrate interval, increasing
+	 * hydration breaks taken during the session and displaying a hydration success message in chat
+	 * </p>
+	 * @since 2.0.0
+	 */
+	private void handleHydrateHydrateCommand()
+	{
+		hydrateBetweenHydrationBreaks();
+		setResetState(true);
+		final String hydratedString = "Successfully hydrated before reminder interval finished";
+		sendHydrateEmojiChatMessage(ChatMessageType.GAMEMESSAGE, hydratedString);
 	}
 
 	/**
@@ -731,5 +747,16 @@ public class HydrateReminderPlugin extends Plugin
 	public void incrementCurrentSessionHydrationBreaks()
 	{
 		setCurrentSessionHydrationBreaks(getCurrentSessionHydrationBreaks() + HYDRATION_BREAK_INCREMENT);
+	}
+
+	/**
+	 * <p> Takes a hydration break before the interval is finished
+	 * </p>
+	 * @since 2.0.0
+	 */
+	public void hydrateBetweenHydrationBreaks()
+	{
+		incrementCurrentSessionHydrationBreaks();
+		resetHydrateReminderTimeInterval();
 	}
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -352,6 +352,7 @@ public class HydrateReminderPlugin extends Plugin
 							handleHydrateResetCommand();
 							break;
 						case HYDRATE:
+							handleHydrateHydrateCommand();
 							break;
 						case HELP:
 							handleHydrateHelpCommand();

--- a/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
@@ -11,6 +11,7 @@ public class HydrateReminderCommandArgsTest
         assertEquals("next", HydrateReminderCommandArgs.NEXT.toString());
         assertEquals("prev", HydrateReminderCommandArgs.PREV.toString());
         assertEquals("reset", HydrateReminderCommandArgs.RESET.toString());
+        assertEquals("hydrate", HydrateReminderCommandArgs.HYDRATE.toString());
         assertEquals("help", HydrateReminderCommandArgs.HELP.toString());
         assertEquals("total", HydrateReminderCommandArgs.TOTAL.toString());
     }
@@ -21,12 +22,14 @@ public class HydrateReminderCommandArgsTest
         assertEquals("next", HydrateReminderCommandArgs.NEXT.getCommandArg());
         assertEquals("prev", HydrateReminderCommandArgs.PREV.getCommandArg());
         assertEquals("reset", HydrateReminderCommandArgs.RESET.getCommandArg());
+        assertEquals("hydrate", HydrateReminderCommandArgs.HYDRATE.getCommandArg());
         assertEquals("help", HydrateReminderCommandArgs.HELP.getCommandArg());
         assertEquals("total", HydrateReminderCommandArgs.TOTAL.getCommandArg());
 
         assertEquals("n", HydrateReminderCommandArgs.NEXT.getCommandArgAbbr());
         assertEquals("p", HydrateReminderCommandArgs.PREV.getCommandArgAbbr());
         assertEquals("r", HydrateReminderCommandArgs.RESET.getCommandArgAbbr());
+        assertEquals("hr", HydrateReminderCommandArgs.HYDRATE.getCommandArgAbbr());
         assertEquals("h", HydrateReminderCommandArgs.HELP.getCommandArgAbbr());
         assertEquals("t", HydrateReminderCommandArgs.TOTAL.getCommandArgAbbr());
     }
@@ -37,12 +40,14 @@ public class HydrateReminderCommandArgsTest
         assertEquals(HydrateReminderCommandArgs.NEXT, HydrateReminderCommandArgs.getValue("next"));
         assertEquals(HydrateReminderCommandArgs.PREV, HydrateReminderCommandArgs.getValue("prev"));
         assertEquals(HydrateReminderCommandArgs.RESET, HydrateReminderCommandArgs.getValue("reset"));
+        assertEquals(HydrateReminderCommandArgs.HYDRATE, HydrateReminderCommandArgs.getValue("hydrate"));
         assertEquals(HydrateReminderCommandArgs.HELP, HydrateReminderCommandArgs.getValue("help"));
         assertEquals(HydrateReminderCommandArgs.TOTAL, HydrateReminderCommandArgs.getValue("total"));
 
         assertEquals(HydrateReminderCommandArgs.NEXT, HydrateReminderCommandArgs.getValue("n"));
         assertEquals(HydrateReminderCommandArgs.PREV, HydrateReminderCommandArgs.getValue("p"));
         assertEquals(HydrateReminderCommandArgs.RESET, HydrateReminderCommandArgs.getValue("r"));
+        assertEquals(HydrateReminderCommandArgs.HYDRATE, HydrateReminderCommandArgs.getValue("hr"));
         assertEquals(HydrateReminderCommandArgs.HELP, HydrateReminderCommandArgs.getValue("h"));
         assertEquals(HydrateReminderCommandArgs.TOTAL, HydrateReminderCommandArgs.getValue("t"));
     }

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -36,6 +36,15 @@ public class HydrateReminderPluginTest
     }
 
     @Test
+    public void shouldIncrementNumberOfHydrationBreaksTakenByHydrateForTheCurrentSession()
+    {
+        hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
+        hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
+        hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
+        assertEquals(3, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
+    }
+
+    @Test
     public void initShouldSetTheCorrectResetState()
     {
         assertFalse(hydrateReminderPlugin.isResetState());
@@ -106,10 +115,18 @@ public class HydrateReminderPluginTest
     }
 
     @Test
-    public void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred()
+    public void shouldSetLastHydrateInstantAfterHydrateResetHasOccurred()
     {
         assertFalse(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
         hydrateReminderPlugin.resetHydrateReminderTimeInterval();
+        assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
+    }
+
+    @Test
+    public void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred()
+    {
+        assertFalse(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
+        hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
         assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
     }
 


### PR DESCRIPTION
## Associated Issue
Closes issue #145 add hydrate chat command done

## Implemented Solution
Implemented hydrate command by calling the reset command and using the increment hydration method, problems could ariese of the implementation of reset command changes. 

## Testing Details
Ran the unit test and tested it in game, all seems to work okey
Operating System: Windows 10 Home version 21H1
RuneLite Version: 1.8.27

## Screenshots
![Captura](https://user-images.githubusercontent.com/47374512/179079073-20289e35-878a-47df-8859-713067dff485.PNG)

