### PR TITLE
Add personalised hydration break messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.27'
+def runeLiteVersion = '1.8.29'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/hydratereminder/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/HydrateBreakMessageDictionary.java
@@ -1,0 +1,53 @@
+package com.hydratereminder;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class HydrateBreakMessageDictionary {
+    /**
+     * Hydrate Reminder interval break text to display
+     */
+    private static final List<String> HYDRATE_BREAK_TEXT_LIST =
+            Collections.unmodifiableList(
+                    new ArrayList<String>() {{
+                        add("It's time for a quick hydration break");
+                        add("Dehydration causes fatigue so take a hydration break");
+                        add("It's time to drink some good ol' water");
+                        add("Stay healthy by taking a hydration break");
+                        add("Time to glug, glug, glug some water");
+                        add("It is now time to take a hydration break");
+                        add("Time to hydrate");
+                        add("Power up with a hydration break now");
+                        add("Got water? It's time to hydrate");
+                        add("Cheers to this hydration break");
+                        add("Hydration time is now");
+                        add("Fuel up with a hydration break");
+                        add("3... 2... 1... It's hydration time");
+                        add("Feeling parched yet? It's hydration time");
+                        add("Now would be a fantastic time to hydrate");
+                        add("Water... you need... water");
+                        add("Thirsty? Time to grab a drink");
+                        add("Water: a liquid that is necessary for life. Why don't you drink some");
+                        add("Hello, this is your reminder to take a hydration break");
+                        add("Remember to stay hydrated");
+                        add("What'cha drinking there? It's time to take another sip");
+                        add("Ding ding ding! Hydration time");
+                        add("Everyone needs water, you should drink some now");
+                        add("Time for another glass of water");
+                        add("You've been grinding hard, time to reward your self with a hydration break");
+                        add("Water makes the world go 'round, you should drink some now");
+                        add("Hydration can improve your ability to focus, time for a hydration break");
+                        add("Time to take a break and hydrate");
+                        add("Dehydration can cause you to feel dizzy and lightheaded, take a hydration break");
+                        add("Dehydration can cause dry mouth, lips, and eyes. Take a hydration break");
+                    }});
+
+    public static String getRandomHydrateBreakMessage() {
+        final SecureRandom randomGenerator = new SecureRandom();
+        final int randomNumber = randomGenerator.nextInt(HYDRATE_BREAK_TEXT_LIST.size());
+        return HYDRATE_BREAK_TEXT_LIST.get(randomNumber);
+    }
+
+}

--- a/src/main/java/com/hydratereminder/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/HydrateBreakMessageDictionary.java
@@ -6,10 +6,20 @@ import java.util.Collections;
 import java.util.List;
 
 class HydrateBreakMessageDictionary {
+
     /**
-     * Hydrate Reminder interval break text to display
+     * Hydrate Reminder interval break text to display in straightforward form
      */
-    private static final List<String> HYDRATE_BREAK_TEXT_LIST =
+    private static final List<String> HYDRATE_BREAK_STRAIGHTFORWARD_TEXT_LIST =
+            Collections.unmodifiableList(
+                    new ArrayList<String>() {{
+                        add("It's time for a quick hydration break");
+                    }}
+            );
+    /**
+     * Hydrate Reminder interval break text to display in funny form
+     */
+    private static final List<String> HYDRATE_BREAK_FUNNY_TEXT_LIST =
             Collections.unmodifiableList(
                     new ArrayList<String>() {{
                         add("It's time for a quick hydration break");
@@ -42,12 +52,26 @@ class HydrateBreakMessageDictionary {
                         add("Time to take a break and hydrate");
                         add("Dehydration can cause you to feel dizzy and lightheaded, take a hydration break");
                         add("Dehydration can cause dry mouth, lips, and eyes. Take a hydration break");
-                    }});
+                    }}
+            );
 
-    public static String getRandomHydrateBreakMessage() {
-        final SecureRandom randomGenerator = new SecureRandom();
-        final int randomNumber = randomGenerator.nextInt(HYDRATE_BREAK_TEXT_LIST.size());
-        return HYDRATE_BREAK_TEXT_LIST.get(randomNumber);
+    public static String getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType personalityType)
+    {
+        String breakMessage;
+        switch (personalityType)
+        {
+            case STRAIGHTFORWARD:
+                breakMessage = HYDRATE_BREAK_STRAIGHTFORWARD_TEXT_LIST.get(0);
+                break;
+            case FUN:
+                final SecureRandom randomGenerator = new SecureRandom();
+                final int randomNumber = randomGenerator.nextInt(HYDRATE_BREAK_FUNNY_TEXT_LIST.size());
+                breakMessage = HYDRATE_BREAK_FUNNY_TEXT_LIST.get(randomNumber);
+                break;
+            default:
+                throw new IllegalStateException("Provided personality type is not supported");
+        }
+        return breakMessage;
     }
 
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderConfig.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderConfig.java
@@ -223,4 +223,22 @@ public interface HydrateReminderConfig extends Config
 	{
 		return HydrateReminderTimerImages.CUP_OF_WATER_IMAGE;
 	}
+
+	/**
+	 * <p>Allows the player to set the type of his personality based on which he will receive personalized messages
+	 * </p>
+	 * @return the type of personality
+	 * @since 2.0.0
+	 */
+	@ConfigItem(
+			keyName = "hydrateReminderPersonalityType",
+			name = "Personality type",
+			description = "Sets the type of personality by which different messages will be displayed when hydrating",
+			position = 11
+	)
+	default HydrateReminderPersonalityType hydrateReminderPersonalityType()
+	{
+		return HydrateReminderPersonalityType.FUN;
+	}
+
 }

--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HydrateReminderPersonalityType
 {
-    STRAIGHTFORWARD("Straightforward"),
+    SIMPLE("Simple"),
     FUN("Fun");
 
     private final String personalityType;

--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-enum HydrateReminderPersonalityType
+public enum HydrateReminderPersonalityType
 {
     STRAIGHTFORWARD("Straightforward"),
     FUN("Fun");

--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -1,0 +1,26 @@
+package com.hydratereminder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+enum HydrateReminderPersonalityType
+{
+    STRAIGHTFORWARD("Straightforward"),
+    FUN("Fun");
+
+    private final String personalityType;
+
+    /**
+     * <p>Get the personality type as a String
+     * </p>
+     * @return personality type
+     * @since 2.0.0
+     */
+    @Override
+    public String toString()
+    {
+        return getPersonalityType();
+    }
+}

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -67,44 +67,6 @@ import java.util.List;
 public class HydrateReminderPlugin extends Plugin
 {
 	/**
-	 * Hydrate Reminder interval break text to display
-	 */
-	private static final List<String> HYDRATE_BREAK_TEXT_LIST =
-			Collections.unmodifiableList(
-					new ArrayList<String>() {{
-						add("It's time for a quick hydration break");
-						add("Dehydration causes fatigue so take a hydration break");
-						add("It's time to drink some good ol' water");
-						add("Stay healthy by taking a hydration break");
-						add("Time to glug, glug, glug some water");
-						add("It is now time to take a hydration break");
-						add("Time to hydrate");
-						add("Power up with a hydration break now");
-						add("Got water? It's time to hydrate");
-						add("Cheers to this hydration break");
-						add("Hydration time is now");
-						add("Fuel up with a hydration break");
-						add("3... 2... 1... It's hydration time");
-						add("Feeling parched yet? It's hydration time");
-						add("Now would be a fantastic time to hydrate");
-						add("Water... you need... water");
-						add("Thirsty? Time to grab a drink");
-						add("Water: a liquid that is necessary for life. Why don't you drink some");
-						add("Hello, this is your reminder to take a hydration break");
-						add("Remember to stay hydrated");
-						add("What'cha drinking there? It's time to take another sip");
-						add("Ding ding ding! Hydration time");
-						add("Everyone needs water, you should drink some now");
-						add("Time for another glass of water");
-						add("You've been grinding hard, time to reward your self with a hydration break");
-						add("Water makes the world go 'round, you should drink some now");
-						add("Hydration can improve your ability to focus, time for a hydration break");
-						add("Time to take a break and hydrate");
-						add("Dehydration can cause you to feel dizzy and lightheaded, take a hydration break");
-						add("Dehydration can cause dry mouth, lips, and eyes. Take a hydration break");
-					}});
-
-	/**
 	 * Hydrate Reminder startup welcome text to display
 	 */
 	private static final List<String> HYDRATE_WELCOME_TEXT_LIST =
@@ -655,10 +617,8 @@ public class HydrateReminderPlugin extends Plugin
 	 */
 	private String getHydrateReminderMessage()
 	{
-		final Random randomGenerator = new Random();
 		final String playerName = Objects.requireNonNull(client.getLocalPlayer()).getName();
-		final String hydrateReminderMessage = HYDRATE_BREAK_TEXT_LIST.get(
-				randomGenerator.nextInt(HYDRATE_BREAK_TEXT_LIST.size()));
+		final String hydrateReminderMessage = HydrateBreakMessageDictionary.getRandomHydrateBreakMessage();
 		return String.format("%s, %s.", hydrateReminderMessage, playerName);
 	}
 

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -51,7 +51,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.List;
 
-import static com.hydratereminder.HydrateBreakMessageDictionary.getRandomHydrateBreakMessageForPersonality;
+import static com.hydratereminder.dictionary.HydrateBreakMessageDictionary.getRandomHydrateBreakMessageForPersonality;
 
 /**
  * <p>The main plugin logic for the Hydrate Reminder plugin

--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -51,6 +51,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.List;
 
+import static com.hydratereminder.HydrateBreakMessageDictionary.getRandomHydrateBreakMessageForPersonality;
+
 /**
  * <p>The main plugin logic for the Hydrate Reminder plugin
  * </p>
@@ -618,7 +620,8 @@ public class HydrateReminderPlugin extends Plugin
 	private String getHydrateReminderMessage()
 	{
 		final String playerName = Objects.requireNonNull(client.getLocalPlayer()).getName();
-		final String hydrateReminderMessage = HydrateBreakMessageDictionary.getRandomHydrateBreakMessage();
+		final HydrateReminderPersonalityType typeOfPersonality = config.hydrateReminderPersonalityType();
+		final String hydrateReminderMessage = getRandomHydrateBreakMessageForPersonality(typeOfPersonality);
 		return String.format("%s, %s.", hydrateReminderMessage, playerName);
 	}
 

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -1,11 +1,13 @@
-package com.hydratereminder;
+package com.hydratereminder.dictionary;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-class HydrateBreakMessageDictionary {
+import com.hydratereminder.HydrateReminderPersonalityType;
+
+public class HydrateBreakMessageDictionary {
 
     /**
      * Hydrate Reminder interval break text to display in straightforward form

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -10,9 +10,9 @@ import com.hydratereminder.HydrateReminderPersonalityType;
 public class HydrateBreakMessageDictionary {
 
     /**
-     * Hydrate Reminder interval break text to display in straightforward form
+     * Hydrate Reminder interval break text to display in simple form
      */
-    private static final List<String> HYDRATE_BREAK_STRAIGHTFORWARD_TEXT_LIST =
+    private static final List<String> HYDRATE_BREAK_SIMPLE_TEXT_LIST =
             Collections.unmodifiableList(
                     new ArrayList<String>() {{
                         add("It's time for a quick hydration break");
@@ -62,8 +62,8 @@ public class HydrateBreakMessageDictionary {
         String breakMessage;
         switch (personalityType)
         {
-            case STRAIGHTFORWARD:
-                breakMessage = HYDRATE_BREAK_STRAIGHTFORWARD_TEXT_LIST.get(0);
+            case SIMPLE:
+                breakMessage = HYDRATE_BREAK_SIMPLE_TEXT_LIST.get(0);
                 break;
             case FUN:
                 final SecureRandom randomGenerator = new SecureRandom();

--- a/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
+++ b/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
@@ -1,0 +1,38 @@
+package com.hydratereminder.dictionary;
+
+import com.hydratereminder.HydrateReminderPersonalityType;
+import org.junit.Test;
+
+import static com.hydratereminder.dictionary.HydrateBreakMessageDictionary.getRandomHydrateBreakMessageForPersonality;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class HydrateBreakMessageDictionaryTest {
+
+    @Test
+    public void shouldChooseStraightforwardMessageWhenTheTypeIsStraightforward() {
+        // given
+        final HydrateReminderPersonalityType personalityType = HydrateReminderPersonalityType.STRAIGHTFORWARD;
+        final String expectedMessage = "It's time for a quick hydration break";
+
+        // when
+        final String message = getRandomHydrateBreakMessageForPersonality(personalityType);
+
+        // then
+        assertEquals(expectedMessage, message);
+    }
+
+    @Test
+    public void shouldChooseFunnyMessageWhenThePersonalityTypeIsFun() {
+        // given
+        final HydrateReminderPersonalityType personalityType = HydrateReminderPersonalityType.FUN;
+        final String notExpectedMessage = "It's time for a quick hydration break";
+
+        // when
+        final String message = getRandomHydrateBreakMessageForPersonality(personalityType);
+
+        // then
+        assertNotEquals(notExpectedMessage, message);
+    }
+
+}

--- a/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
+++ b/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
@@ -10,9 +10,9 @@ import static org.junit.Assert.assertNotEquals;
 public class HydrateBreakMessageDictionaryTest {
 
     @Test
-    public void shouldChooseStraightforwardMessageWhenTheTypeIsStraightforward() {
+    public void shouldChooseSimpleMessageWhenTheTypeIsSimple() {
         // given
-        final HydrateReminderPersonalityType personalityType = HydrateReminderPersonalityType.STRAIGHTFORWARD;
+        final HydrateReminderPersonalityType personalityType = HydrateReminderPersonalityType.SIMPLE;
         final String expectedMessage = "It's time for a quick hydration break";
 
         // when


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #144

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Adding the ability to choose personality type - either fun or straightforward.
Personality type is used to choose proper message set when notifying about hydrate break.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
RuneLite Version: 1.8.29

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
