### PR TITLE
Show informative tooltip when mouse is hovered over infobox

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderTimer.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderTimer.java
@@ -46,6 +46,8 @@ import net.runelite.client.ui.overlay.infobox.InfoBoxPriority;
 @ToString
 public class HydrateReminderTimer extends InfoBox
 {
+    private static final String TOOLTIP_INFORMATION = "Time until next hydration break";
+
     /**
      * <p>The text color to display in the hydrate reminder infobox
      * </p>
@@ -89,5 +91,15 @@ public class HydrateReminderTimer extends InfoBox
         final int seconds = (int) ((timeRemaining.toMillis() / 1000L) % 60);
         final int minutes = (int) (timeRemaining.toMillis() / 60000L);
         return String.format("%d:%02d", Math.max(minutes, 0), Math.max(seconds, 0));
+    }
+
+    /**
+     * <p>Gets the text that is displayed in the tooltip
+     * </p>
+     * @return text displayed when mouse cursor is hovered over infobox
+     */
+    @Override
+    public String getTooltip() {
+        return TOOLTIP_INFORMATION;
     }
 }


### PR DESCRIPTION
## Associated Issue
Show informative tooltip when mouse is hovered over infobox
Closes #207 

## Implemented Solution
Add getTooltip() method that overrides parent method from inherited InfoBox class in HydrateReminderTimer class. 

## Testing Details
No unit tests needed. Checked in game.

Operating System: Windows 11
RuneLite Version: 1.8.33.3

## Screenshots
![image](https://user-images.githubusercontent.com/94566117/192582309-8aff3d39-1949-4cdc-aacf-f5eb06781273.png)
