### PR TITLE
Added polite personality and dictionary for hydration reminder

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -9,6 +9,7 @@ public enum HydrateReminderPersonalityType
 {
     SIMPLE("Simple"),
     FUN("Fun"),
+    POLITE("Polite"),
     CARING("Caring");
 
     private final String personalityType;

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -81,6 +81,29 @@ public class HydrateBreakMessageDictionary {
                     }}
             );
     
+    /**
+     * Hydrate Reminder interval break text to display in polite form
+     */
+    private static final List<String> HYDRATE_BREAK_POLITE_TEXT_LIST =
+            Collections.unmodifiableList(
+                    new ArrayList<String>() {{
+                        add("Drinking water will boost your concentration. Kindly have a sip");
+                        add("Your beautiful skin will shine brighter when hydrated. Please go ahead");
+                        add("If you don't mind, please take a short break to hydrate");
+                        add("Hydration time! Please drink some water");
+                        add("Keep that smile on! Kindly have some water");
+                        add("Water is the best of all things. Please keep yourself hydrated");
+                        add("I'd prefer you to take a quick hydration break, please");
+                        add("Let your body sing you a lullaby. Please hydrate");
+                        add("It'll be great if you take a small hydration break");
+                        add("You seem dehydrated! Please drink some water");
+                        add("Please don't hesitate to take a small water break");
+                        add("Please take care of yourself! Drink some water");
+                        add("Your future seems brighter when you drink water. Please have a sip");
+                        add("To be honest, you really need a hydration break. Kindly grab a drink");                  
+                    }}
+            );
+    
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {
         final SecureRandom randomGenerator = new SecureRandom();
@@ -101,6 +124,9 @@ public class HydrateBreakMessageDictionary {
                 break;
             case CARING:
                 breakMessage = getRandomBreakMessage(HYDRATE_BREAK_CARING_TEXT_LIST);
+                break;
+            case POLITE:
+                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_POLITE_TEXT_LIST);
                 break;
             default:
                 throw new IllegalStateException("Provided personality type is not supported");


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #195 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added the POLITE personality inside [HydrateReminderPersonalityType.java](https://github.com/jmakhack/hydrate-reminder/blob/master/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java).
Added the POLITE dictionary into a separate function and then added the option to the switch case inside [HydrateBreakMessageDictionary.java](https://github.com/jmakhack/hydrate-reminder/blob/master/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java)

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->

No testing has been done, as the change only adds a new option for the hydration message sent to users. No new functionality was added nor a change in the project functionality was done.
(However, testing will be done if required.)

