### PR TITLE
Adding automation to set reviewers and assignees on pull requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Kaushik-Iyer
+* @jmakhack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jmakhack
+* @Kaushik-Iyer

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@jmakhack
+* @jmakhack

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.0


### PR DESCRIPTION
## Associated Issue
Adding automation to set reviewers and assignees on pull requests
Closes #224

## Implemented Solution
Automation for assignees is done by adding a new github action (https://github.com/marketplace/actions/auto-author-assign)
Automation for reviewer is done by changing the CODEOWNERS file in the .github folder (By adding one asterisk before the account name)

## Testing Details
I tested by forking, and making my account as the CODEOWNER for that forked repo, and asking a friend to make a pull request to that repository, and observing the auto assigned reviewer and assignee

Operating System: Windows 11
RuneLite Version: v1.1.1

## Screenshots
I deleted the testing repository before making this pull request :/
