### PR TITLE
Add new hydrate message personality type: Motivational

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -10,7 +10,7 @@ public enum HydrateReminderPersonalityType
     SIMPLE("Simple"),
     FUN("Fun"),
     POLITE("Polite"),
-    MOTIVATIONAL("motivational"),
+    MOTIVATIONAL("Motivational"),
     CARING("Caring");
 
     private final String personalityType;

--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -10,6 +10,7 @@ public enum HydrateReminderPersonalityType
     SIMPLE("Simple"),
     FUN("Fun"),
     POLITE("Polite"),
+    MOTIVATIONAL("motivational"),
     CARING("Caring");
 
     private final String personalityType;

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -104,6 +104,29 @@ public class HydrateBreakMessageDictionary {
                     }}
             );
     
+     /**
+     * Hydrate Reminder interval break text to display in motivational form
+     */
+    private static final List<String> HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST =
+            Collections.unmodifiableList(
+                    new ArrayList<String>() {{
+                        add("Water is the Driving Force of All Nature. Grab some");
+                        add("Water is the Best Natural Remedy. Drink Your Way to Better Health");
+                        add("Drink Pure Water. Stay Healthy. Stay lively");
+                        add("Hydration time! Drink some water and keep going");
+                        add("There is No Small Pleasure in Pure Water. Enjoy it");
+                        add("Water is the best of all things. Stay hydrated and rule the day");
+                        add("When the Well is Dry, We’ll Know the Worth of Water. Drink well, live well");
+                        add("Do your body a favor, stay hydrated, stay healthy");
+                        add("Pure Water is the World’s First and Foremost Medicine. Use it");
+                        add("Water is Your Best Friend for Life. Catch up with a break");
+                        add("Keep Calm & Drink Water");
+                        add("Water is Life. Don’t Waste It. Drink it");
+                        add("It's time to rejuvinate your body with water for a better and healthier you");
+                        add("Thousands Have Lived Without Love, Not One Without Water. Take a sip");                  
+                    }}
+            );
+    
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {
         final SecureRandom randomGenerator = new SecureRandom();
@@ -127,6 +150,9 @@ public class HydrateBreakMessageDictionary {
                 break;
             case POLITE:
                 breakMessage = getRandomBreakMessage(HYDRATE_BREAK_POLITE_TEXT_LIST);
+                break;
+            case MOTIVATIONAL:
+                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
                 break;
             default:
                 throw new IllegalStateException("Provided personality type is not supported");


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #191 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added the MOTIVATIONAL personality inside [HydrateReminderPersonalityType.java](https://github.com/jmakhack/hydrate-reminder/blob/master/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java).
Added the MOTIVATIONAL dictionary into a separate function and then added the option to the switch case inside [HydrateBreakMessageDictionary.java](https://github.com/jmakhack/hydrate-reminder/blob/master/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java)

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
No testing has been done, as the change only adds a new option for the hydration message sent to users. No new functionality was added nor a change in the project functionality was done.
(However, testing will be done if required.)
