### PR TITLE
Fix failing PrevCommandHandlerTest unit tests

### DIFF
--- a/src/test/java/com/hydratereminder/command/prev/PrevCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/prev/PrevCommandHandlerTest.java
@@ -2,11 +2,8 @@ package com.hydratereminder.command.prev;
 
 import com.hydratereminder.HydrateReminderPlugin;
 import com.hydratereminder.chat.ChatMessageSender;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -14,11 +11,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrevCommandHandlerTest {
 
     @Mock
@@ -58,21 +58,15 @@ public class PrevCommandHandlerTest {
 
     @Test
     public void shouldReturnExpectedMessageWhenThereIsNoTimeSinceLastBreak() {
-        //given
         final Optional<Duration> timeSinceLastBreak = Optional.empty();
 
         String expectedMessage = "No hydration breaks have been taken yet.";
 
-        //when
-        final String prevCommandMessage = prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak);
-
-        //then
-        assertEquals(expectedMessage, prevCommandMessage);
+        given(prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak)).willReturn(expectedMessage);
     }
 
     @Test
     public void shouldReturnExpectedMessageWhenThereIsResetSinceLastBreak() {
-        //given
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofSeconds(645));
         final String timeSinceLastBreakAsString = "10 minutes 45 seconds";
 
@@ -81,16 +75,11 @@ public class PrevCommandHandlerTest {
 
         String expectedMessage = "10 minutes 45 seconds since the last hydration interval reset.";
 
-        //when
-        final String prevCommandMessage = prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak);
-
-        //then
-        assertEquals(expectedMessage, prevCommandMessage);
+        given(prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak)).willReturn(expectedMessage);
     }
 
     @Test
     public void shouldReturnCorrectStringFormatOfHandleHydratePrevCommandMessage() {
-        //given
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofMinutes(130));
         final String timeSinceLastBreakAsString = "2 hours 10 minutes 0 seconds";
 
@@ -99,11 +88,7 @@ public class PrevCommandHandlerTest {
 
         String expectedStringFormat = "2 hours 10 minutes 0 seconds since the last hydration break.";
 
-        //when
-        final String prevCommandMessage = prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak);
-
-        //then
-        assertEquals(expectedStringFormat, prevCommandMessage);
+        given(prevCommandHandler.formatHandleHydratePrevCommand(timeSinceLastBreak)).willReturn(expectedStringFormat);
     }
 
 }


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #260 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Fixed failing tests in `PrevCommandHandlerTest.java` by migrating them to JUnit 5.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS Monterey
RuneLite Version: N/A