### PR TITLE
use default locale in toLowerCase()

### DIFF
--- a/src/main/java/com/hydratereminder/command/CommandInvoker.java
+++ b/src/main/java/com/hydratereminder/command/CommandInvoker.java
@@ -1,5 +1,7 @@
 package com.hydratereminder.command;
 
+import java.util.Locale;
+
 import com.hydratereminder.HydrateReminderCommandArgs;
 import com.hydratereminder.chat.ChatMessageSender;
 import net.runelite.api.events.CommandExecuted;
@@ -29,7 +31,7 @@ public class CommandInvoker {
         }
         final String[] commandArguments = commandExecuted.getArguments();
         if (isNotEmpty(commandArguments)) {
-            final String rawCommand = commandArguments[0].toLowerCase();
+            final String rawCommand = commandArguments[0].toLowerCase(Locale.getDefault());
             try {
                 final HydrateReminderCommandArgs commandType = getCommandType(rawCommand);
                 final Command command = commandCreator.createFrom(commandType);


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #278 

## Implemented Solution
use java.util.Locale package's getDefaultLocale() to get the system locale.
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: macOS
RuneLite Version: n/a

ran unit tests in Intellij IDE for CommandInvoker

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
