### PR TITLE
Add serialVersionUID field to exceptions

### DIFF
--- a/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
@@ -5,6 +5,7 @@ import static com.hydratereminder.Commons.RUNELITE_COMMAND_PREFIX;
 
 public class NotRecognizedCommandException extends RuntimeException {
     private final String reason;
+    private static final long serialVersionUID = 3907006L;
 
     public NotRecognizedCommandException(String unsupportedCommandName) {
         this.reason = String.format(

--- a/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
@@ -7,6 +7,7 @@ import static com.hydratereminder.Commons.RUNELITE_COMMAND_PREFIX;
 
 public class NotSupportedCommandException extends RuntimeException {
     private final String reason;
+    private static final long serialVersionUID = 126859L;
 
     public NotSupportedCommandException(HydrateReminderCommandArgs unrecognizedCommandName) {
         this.reason = String.format(


### PR DESCRIPTION
## Associated Issue
Closes #279 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
According to the [java.io.Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html) documentation:
`A serializable class can declare its own serialVersionUID explicitly by declaring a field named "serialVersionUID" that must be static, final, and of type long.`
So I've decided to make those fields private since there's no strict requirement for visibility modifiers on this field.
## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: Linux Mint 20.3 Cinnamon
RuneLite Version: n/a