### PR TITLE
Fix implicit switch fall through issue

### DIFF
--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -272,15 +272,15 @@ public class HydrateBreakMessageDictionary {
 
     public static String getRandomPersonality()
     {
-        List<HydrateReminderPersonalityType> personalityTypes = getPersonalityTypesWithoutRandom();
-        int randomNumber = ThreadLocalRandom.current().nextInt(0, personalityTypes.size());
-        HydrateReminderPersonalityType personalityType = personalityTypes.get(randomNumber);;
+        final List<HydrateReminderPersonalityType> personalityTypes = getPersonalityTypesWithoutRandom();
+        final int randomNumber = ThreadLocalRandom.current().nextInt(0, personalityTypes.size());
+        final HydrateReminderPersonalityType personalityType = personalityTypes.get(randomNumber);
         return getRandomHydrateBreakMessageForPersonality(personalityType);
     }
 
     private static List<HydrateReminderPersonalityType> getPersonalityTypesWithoutRandom()
     {
-        List<HydrateReminderPersonalityType> personalityTypes = Arrays.asList(HydrateReminderPersonalityType.values());
+        final List<HydrateReminderPersonalityType> personalityTypes = Arrays.asList(HydrateReminderPersonalityType.values());
         personalityTypes.remove(HydrateReminderPersonalityType.RANDOM);
         return personalityTypes;
     }

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -2,6 +2,7 @@ package com.hydratereminder.dictionary;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -261,44 +262,27 @@ public class HydrateBreakMessageDictionary {
                 breakMessage = getRandomBreakMessage(HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
                 break;
             case RANDOM:
-                getRandomPersonality();
+                breakMessage = getRandomPersonality();
+                break;
             default:
                 throw new IllegalStateException("Provided personality type is not supported");
         }
         return breakMessage;
     }
 
-    public static void getRandomPersonality()
+    public static String getRandomPersonality()
     {
-            int randomNumber = ThreadLocalRandom.current().nextInt(1, 9);
-            switch (randomNumber) {
-                case 1:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.SIMPLE);
-                    break;
-                case 2:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.CARING);
-                    break;
-                case 3:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.ROMANTIC);
-                    break;
-                case 4:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.POLITE);
-                    break;
-                case 5:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.NERDY);
-                    break;
-                case 6:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.PIRATE);
-                    break;
-                case 7:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.MOTIVATIONAL);
-                    break;
-                case 8:
-                    getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType.AGGRESSIVE);
-                    break;
-                default:
-                    throw new IllegalStateException("Not VALID" + randomNumber);
-            }
+        List<HydrateReminderPersonalityType> personalityTypes = getPersonalityTypesWithoutRandom();
+        int randomNumber = ThreadLocalRandom.current().nextInt(0, personalityTypes.size());
+        HydrateReminderPersonalityType personalityType = personalityTypes.get(randomNumber);;
+        return getRandomHydrateBreakMessageForPersonality(personalityType);
+    }
+
+    private static List<HydrateReminderPersonalityType> getPersonalityTypesWithoutRandom()
+    {
+        List<HydrateReminderPersonalityType> personalityTypes = Arrays.asList(HydrateReminderPersonalityType.values());
+        personalityTypes.remove(HydrateReminderPersonalityType.RANDOM);
+        return personalityTypes;
     }
 
 }

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -262,7 +262,7 @@ public class HydrateBreakMessageDictionary {
                 breakMessage = getRandomBreakMessage(HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
                 break;
             case RANDOM:
-                breakMessage = getRandomPersonality();
+                breakMessage = getRandomPersonalityMessage();
                 break;
             default:
                 throw new IllegalStateException("Provided personality type is not supported");
@@ -270,7 +270,13 @@ public class HydrateBreakMessageDictionary {
         return breakMessage;
     }
 
-    public static String getRandomPersonality()
+    /**
+     * Selects random personality from {@link HydrateReminderPersonalityType} except
+     * {@link HydrateReminderPersonalityType#RANDOM} and returns message for it.
+     *
+     * @return message for random personality.
+     */
+    public static String getRandomPersonalityMessage()
     {
         final List<HydrateReminderPersonalityType> personalityTypes = getPersonalityTypesWithoutRandom();
         final int randomNumber = ThreadLocalRandom.current().nextInt(0, personalityTypes.size());


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #275 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
I've refactored `getRandomPersonality()` method to return String instead of void, and added missing break statement in switch.
I've also noticed that `getRandomPersonality()` wasn't aware of `FUN` personality, so I've changed the logic to account for all personalities except `RANDOM`.
## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: Linux Mint 20.3 Cinnamon
RuneLite Version: 1.8.34.1