### PR TITLE
Fix to avoid catching generic exception in HydrateEmojiProvider

### DIFF
--- a/src/main/java/com/hydratereminder/chat/HydrateEmojiProvider.java
+++ b/src/main/java/com/hydratereminder/chat/HydrateEmojiProvider.java
@@ -45,7 +45,7 @@ public class HydrateEmojiProvider {
                 final BufferedImage hydrateIcon = ImageUtil.loadImageResource(HydrateReminderPlugin.class, "water_icon.png");
                 final IndexedSprite hydrateSprite = ImageUtil.getImageIndexedSprite(hydrateIcon, client);
                 newModIcons[modIcons.length] = hydrateSprite;
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 log.warn("Failed to load hydrate emoji sprite", e);
             }
             setHydrateEmojiId(Optional.of(modIcons.length));


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #274

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Changed the generic exception that was being catched to a RuntimeException as the ImageUtils methods that are being used within the try block tend to return RuntimeException or IllegalArgumentException both of which would be taken care of by specifying RuntimeException

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: Windows 11
RuneLite Version: 1.9.0

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
