### PR TITLE
Improve example message by including message type

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPlugin.java
@@ -217,8 +217,13 @@ public class HydrateReminderPlugin extends Plugin
 					// only send example chat notification if chat messages are enabled and player is logged in
 					if (config.hydrateReminderChatMessageEnabled() && client.getGameState() == GameState.LOGGED_IN)
 					{
+						HydrateReminderChatMessageType chatType = config.hydrateReminderChatMessageType();
+
 						clientThread.invoke(() ->
-								chatMessageSender.sendHydrateReminderChatMessage("This is how hydrate reminder chat notifications will appear."));
+								chatMessageSender.sendHydrateReminderChatMessage(
+										String.format(
+												"This is how %s hydrate reminder notifications will appear.", chatType
+								)));
 					}
 					break;
 				case "hydrateReminderComputerNotificationEnabled":


### PR DESCRIPTION
## Associated Issue
Include chat message type in example chat message
Closes #295

## Implemented Solution
Add variable for chat message type and used String.format to include it in the message

## Testing Details
Tested in game

Operating System: Windows 11
RuneLite Version: 1.9.0

## Screenshots
![image](https://user-images.githubusercontent.com/58759808/194373727-65919648-ce03-4438-89d7-d91356eaefea.png)
