### PR TITLE
(Codacy issue): JUnit 5 tests should be package-private

### DIFF
--- a/src/test/java/com/hydratereminder/HydrateReminderChatMessageTypeTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderChatMessageTypeTest.java
@@ -1,14 +1,12 @@
 package com.hydratereminder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
 
-public class HydrateReminderChatMessageTypeTest
-{
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HydrateReminderChatMessageTypeTest {
     @Test
-    public void testChatMessageTypeToString()
-    {
+    void testChatMessageTypeToString() {
         assertEquals("Game Message", HydrateReminderChatMessageType.GAMEMESSAGE.toString());
         assertEquals("Broadcast Message", HydrateReminderChatMessageType.BROADCASTMESSAGE.toString());
         assertEquals("Public Chat", HydrateReminderChatMessageType.PUBLICCHAT.toString());

--- a/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderCommandArgsTest.java
@@ -1,16 +1,14 @@
 package com.hydratereminder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.hydratereminder.command.NotRecognizedCommandException;
 import org.junit.jupiter.api.Test;
 
-public class HydrateReminderCommandArgsTest
-{
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HydrateReminderCommandArgsTest {
     @Test
-    public void testCommandArgsToString()
-    {
+    void testCommandArgsToString() {
         assertEquals("next", HydrateReminderCommandArgs.NEXT.toString());
         assertEquals("prev", HydrateReminderCommandArgs.PREV.toString());
         assertEquals("reset", HydrateReminderCommandArgs.RESET.toString());
@@ -20,8 +18,7 @@ public class HydrateReminderCommandArgsTest
     }
 
     @Test
-    public void testAliases()
-    {
+    void testAliases() {
         assertEquals("next", HydrateReminderCommandArgs.NEXT.getCommandArg());
         assertEquals("prev", HydrateReminderCommandArgs.PREV.getCommandArg());
         assertEquals("reset", HydrateReminderCommandArgs.RESET.getCommandArg());
@@ -38,8 +35,7 @@ public class HydrateReminderCommandArgsTest
     }
 
     @Test
-    public void testGetValue()
-    {
+    void testGetValue() {
         assertEquals(HydrateReminderCommandArgs.NEXT, HydrateReminderCommandArgs.getValue("next"));
         assertEquals(HydrateReminderCommandArgs.PREV, HydrateReminderCommandArgs.getValue("prev"));
         assertEquals(HydrateReminderCommandArgs.RESET, HydrateReminderCommandArgs.getValue("reset"));
@@ -56,8 +52,7 @@ public class HydrateReminderCommandArgsTest
     }
 
     @Test
-    public void testGetValueThrowsIfNullCommand()
-    {
+    void testGetValueThrowsIfNullCommand() {
         assertThrows(
                 NotRecognizedCommandException.class,
                 () -> HydrateReminderCommandArgs.getValue(null)
@@ -65,8 +60,7 @@ public class HydrateReminderCommandArgsTest
     }
 
     @Test
-    public void testGetValueThrowsIfInvalidCommand()
-    {
+    void testGetValueThrowsIfInvalidCommand() {
         assertThrows(
                 NotRecognizedCommandException.class,
                 () -> HydrateReminderCommandArgs.getValue("dummy")

--- a/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderPluginTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
-public class HydrateReminderPluginTest {
+class HydrateReminderPluginTest {
     @Mock
     private transient Client client;
     @Mock
@@ -32,12 +32,12 @@ public class HydrateReminderPluginTest {
     private transient HydrateReminderPlugin hydrateReminderPlugin;
 
     @Test
-    public void initShouldReturnZeroHydrationBreaksForTheCurrentSession() {
+    void initShouldReturnZeroHydrationBreaksForTheCurrentSession() {
         assertEquals(0, hydrateReminderPlugin.getCurrentSessionHydrationBreaks());
     }
 
     @Test
-    public void shouldIncrementNumberOfHydrationBreaksForTheCurrentSession() {
+    void shouldIncrementNumberOfHydrationBreaksForTheCurrentSession() {
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
         hydrateReminderPlugin.incrementCurrentSessionHydrationBreaks();
@@ -45,7 +45,7 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldIncrementNumberOfHydrationBreaksTakenByHydrateForTheCurrentSession() {
+    void shouldIncrementNumberOfHydrationBreaksTakenByHydrateForTheCurrentSession() {
         hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
         hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
         hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
@@ -53,12 +53,12 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void initShouldSetTheCorrectResetState() {
+    void initShouldSetTheCorrectResetState() {
         assertFalse(hydrateReminderPlugin.isResetState());
     }
 
     @Test
-    public void shouldSetTheCorrectResetState() {
+    void shouldSetTheCorrectResetState() {
         hydrateReminderPlugin.setResetState(true);
         assertTrue(hydrateReminderPlugin.isResetState());
         hydrateReminderPlugin.setResetState(false);
@@ -66,7 +66,7 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldReturnCorrectStringFormatOfTheTime() {
+    void shouldReturnCorrectStringFormatOfTheTime() {
         assertEquals("1 hour 1 minute 1 second",
                 hydrateReminderPlugin.getTimeDisplay(Duration.ofSeconds(3661)));
         assertEquals("19 hours 15 minutes 39 seconds",
@@ -80,34 +80,34 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldReturnNoDurationWhenThereIsNoLastBreak() {
+    void shouldReturnNoDurationWhenThereIsNoLastBreak() {
         final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(Optional.empty(), Instant.now());
         assertFalse(timeSinceLastBreak.isPresent());
     }
 
     @Test
-    public void shouldReturnDurationWhenThereIsLastBreak() {
+    void shouldReturnDurationWhenThereIsLastBreak() {
         final Optional<Instant> timeOfLastBreak = Optional.of(Instant.now());
         final Optional<Duration> timeSinceLastBreak = hydrateReminderPlugin.getDurationSinceLastBreak(timeOfLastBreak, Instant.now());
         assertTrue(timeSinceLastBreak.isPresent());
     }
 
     @Test
-    public void shouldSetLastHydrateInstantAfterHydrateResetHasOccurred() {
+    void shouldSetLastHydrateInstantAfterHydrateResetHasOccurred() {
         assertFalse(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
         hydrateReminderPlugin.resetHydrateReminderTimeInterval();
         assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
     }
 
     @Test
-    public void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred() {
+    void shouldSetLastHydrateInstantAfterHydrateBreakHasOccurred() {
         assertFalse(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
         hydrateReminderPlugin.hydrateBetweenHydrationBreaks();
         assertTrue(hydrateReminderPlugin.getLastHydrateInstant().isPresent());
     }
 
     @Test
-    public void shoudldGetCorrectDurationFromLastBreakTillNowWhenThereIsLastBreak() {
+    void shouldGetCorrectDurationFromLastBreakTillNowWhenThereIsLastBreak() {
         Instant nowInstant = Instant.now();
         Instant lastBreakInstant = nowInstant.minus(1, ChronoUnit.HOURS);
 
@@ -120,7 +120,7 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldPlayAnimationWhenIncrementingNumberOfHydrationBreaksAndConfigEnabled() {
+    void shouldPlayAnimationWhenIncrementingNumberOfHydrationBreaksAndConfigEnabled() {
         // given
         final Player playerMock = mock(Player.class);
         given(config.hydrateAnimationEnabled()).willReturn(true);
@@ -135,7 +135,7 @@ public class HydrateReminderPluginTest {
     }
 
     @Test
-    public void shouldNotPlayAnimationWhenIncrementingNumberOfHydrationBreaksAndConfigDisabled() {
+    void shouldNotPlayAnimationWhenIncrementingNumberOfHydrationBreaksAndConfigDisabled() {
         // given
         given(config.hydrateAnimationEnabled()).willReturn(false);
 

--- a/src/test/java/com/hydratereminder/HydrateReminderTimerImagesTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderTimerImagesTest.java
@@ -2,14 +2,17 @@ package com.hydratereminder;
 
 import org.junit.jupiter.api.Test;
 
-import static net.runelite.api.ItemID.*;
+import static net.runelite.api.ItemID.BOTTLED_WATER;
+import static net.runelite.api.ItemID.COCONUT_MILK;
+import static net.runelite.api.ItemID.PURPLE_DYE;
+import static net.runelite.api.ItemID.RUM;
+import static net.runelite.api.ItemID.TEAPOT;
+import static net.runelite.api.ItemID.WATERMELON_SLICE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class HydrateReminderTimerImagesTest
-{
+class HydrateReminderTimerImagesTest {
     @Test
-    public void testTimerImagesToString()
-    {
+    void testTimerImagesToString() {
         assertEquals("Cup of Water", HydrateReminderTimerImages.CUP_OF_WATER_IMAGE.toString());
         assertEquals("Cup of Tea", HydrateReminderTimerImages.CUP_OF_TEA_IMAGE.toString());
         assertEquals("Beer", HydrateReminderTimerImages.BEER_IMAGE.toString());
@@ -19,8 +22,7 @@ public class HydrateReminderTimerImagesTest
     }
 
     @Test
-    public void testTimerImagesGetID()
-    {
+    void testTimerImagesGetID() {
         assertEquals(BOTTLED_WATER, HydrateReminderTimerImages.BOTTLED_WATER_IMAGE.getID());
         assertEquals(TEAPOT, HydrateReminderTimerImages.TEAPOT_IMAGE.getID());
         assertEquals(RUM, HydrateReminderTimerImages.RUM_IMAGE.getID());

--- a/src/test/java/com/hydratereminder/HydrateReminderTimerTest.java
+++ b/src/test/java/com/hydratereminder/HydrateReminderTimerTest.java
@@ -13,52 +13,44 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class MockHydrateReminderPlugin extends HydrateReminderPlugin
-{
+class MockHydrateReminderPlugin extends HydrateReminderPlugin {
     public transient Instant instant;
 
     @Override
-    public Instant getNextHydrateReminderInstant()
-    {
+    public Instant getNextHydrateReminderInstant() {
         return instant;
     }
 }
 
-public class HydrateReminderTimerTest
-{
+class HydrateReminderTimerTest {
     private transient MockHydrateReminderPlugin mockHydrateReminderPlugin;
 
     private transient HydrateReminderTimer hydrateReminderTimer;
 
     @BeforeEach
-    public void setupHydrateReminderPlugin()
-    {
+    void setupHydrateReminderPlugin() {
         mockHydrateReminderPlugin = new MockHydrateReminderPlugin();
         final BufferedImage timerImage = ImageUtil.loadImageResource(getClass(), "water_icon.png");
         hydrateReminderTimer = new HydrateReminderTimer(mockHydrateReminderPlugin, timerImage, WHITE);
     }
 
     @Test
-    public void shouldSetInitializedTextColor()
-    {
+    void shouldSetInitializedTextColor() {
         assertEquals(hydrateReminderTimer.getTextColor(), WHITE);
     }
 
     @Test
-    public void shouldReturnTrueOnRender()
-    {
+    void shouldReturnTrueOnRender() {
         assertTrue(hydrateReminderTimer.render());
     }
 
     @Test
-    public void shouldReturnFalseOnCull()
-    {
+    void shouldReturnFalseOnCull() {
         assertFalse(hydrateReminderTimer.cull());
     }
 
     @Test
-    public void shouldHaveNameBasedOnPluginAndClassName()
-    {
+    void shouldHaveNameBasedOnPluginAndClassName() {
         final String pluginName = "MockHydrateReminderPlugin";
         final String className = "HydrateReminderTimer";
         final String finalName = String.join("_", pluginName, className);
@@ -66,22 +58,19 @@ public class HydrateReminderTimerTest
     }
 
     @Test
-    public void shouldDisplayMinutesAndSecondsWhenTimeLeftIsOverAMinute()
-    {
+    void shouldDisplayMinutesAndSecondsWhenTimeLeftIsOverAMinute() {
         mockHydrateReminderPlugin.instant = Instant.now().plus(Duration.ofMinutes(90));
         assertTrue(hydrateReminderTimer.getText().matches("^\\d{2}:\\d{2}$"));
     }
 
     @Test
-    public void shouldDisplayZeroMinutesWhenTimeLeftIsUnderAMinute()
-    {
+    void shouldDisplayZeroMinutesWhenTimeLeftIsUnderAMinute() {
         mockHydrateReminderPlugin.instant = Instant.now().plus(Duration.ofSeconds(45));
         assertTrue(hydrateReminderTimer.getText().matches("^0:\\d{2}$"));
     }
 
     @Test
-    public void shouldDisplayZeroMinutesAndSecondsWhenTimeLeftIsNegative()
-    {
+    void shouldDisplayZeroMinutesAndSecondsWhenTimeLeftIsNegative() {
         mockHydrateReminderPlugin.instant = Instant.now().minus(Duration.ofSeconds(150));
         assertEquals(hydrateReminderTimer.getText(), "0:00");
     }

--- a/src/test/java/com/hydratereminder/chat/ChatMessageSenderTest.java
+++ b/src/test/java/com/hydratereminder/chat/ChatMessageSenderTest.java
@@ -14,7 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class ChatMessageSenderTest {
+class ChatMessageSenderTest {
 
     @Mock
     private transient Client client;
@@ -29,7 +29,7 @@ public class ChatMessageSenderTest {
     private transient ChatMessageSender chatMessageSender;
 
     @Test
-    public void shouldSendChatGameMessageWithoutEmojiWhenEmojiIsNotProvided() {
+    void shouldSendChatGameMessageWithoutEmojiWhenEmojiIsNotProvided() {
         //given
         ChatMessageType expectedChatMessageType = ChatMessageType.GAMEMESSAGE;
         String message = "Hello";
@@ -43,7 +43,7 @@ public class ChatMessageSenderTest {
     }
 
     @Test
-    public void shouldSendChatGameMessageWithEmojiWhenEmojiIsProvided() {
+    void shouldSendChatGameMessageWithEmojiWhenEmojiIsProvided() {
         //given
         ChatMessageType expectedChatMessageType = ChatMessageType.GAMEMESSAGE;
         String message = "Hello";
@@ -57,7 +57,7 @@ public class ChatMessageSenderTest {
     }
 
     @Test
-    public void shouldSendChatMessageWithBroadcastTypeWhenThatTypeWasProvided() {
+    void shouldSendChatMessageWithBroadcastTypeWhenThatTypeWasProvided() {
         //given
         ChatMessageType providedChatMessageType = ChatMessageType.BROADCAST;
         String message = "Hello";

--- a/src/test/java/com/hydratereminder/chat/ChatMessageTypeProviderTest.java
+++ b/src/test/java/com/hydratereminder/chat/ChatMessageTypeProviderTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-public class ChatMessageTypeProviderTest {
+class ChatMessageTypeProviderTest {
 
     @Mock
     private transient HydrateReminderConfig config;
@@ -22,7 +22,7 @@ public class ChatMessageTypeProviderTest {
     private transient ChatMessageTypeProvider chatMessageTypeProvider;
 
     @Test
-    public void shouldReturnGameMessageTypeWhenHydrateReminderChatMessageIsDifferentThanExpected() {
+    void shouldReturnGameMessageTypeWhenHydrateReminderChatMessageIsDifferentThanExpected() {
         //given
         ChatMessageType expectedChatMessageType = ChatMessageType.GAMEMESSAGE;
         given(config.hydrateReminderChatMessageType()).willReturn(HydrateReminderChatMessageType.GAMEMESSAGE);
@@ -35,7 +35,7 @@ public class ChatMessageTypeProviderTest {
     }
 
     @Test
-    public void shouldReturnBroadCastMessageTypeWhenProvideBroadCastMessage() {
+    void shouldReturnBroadCastMessageTypeWhenProvideBroadCastMessage() {
         //given
         ChatMessageType expectedChatMessageType = ChatMessageType.BROADCAST;
         given(config.hydrateReminderChatMessageType()).willReturn(HydrateReminderChatMessageType.BROADCASTMESSAGE);

--- a/src/test/java/com/hydratereminder/chat/HydrateEmojiProviderTest.java
+++ b/src/test/java/com/hydratereminder/chat/HydrateEmojiProviderTest.java
@@ -14,7 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class HydrateEmojiProviderTest {
+class HydrateEmojiProviderTest {
 
     @Mock
     private transient Client client;
@@ -24,7 +24,7 @@ public class HydrateEmojiProviderTest {
 
 
     @Test
-    public void shouldSetHydrateEmojiIdTo3WhenHydrateEmojiIsLoadedAndHave2Elements() {
+    void shouldSetHydrateEmojiIdTo3WhenHydrateEmojiIsLoadedAndHave2Elements() {
         //given
         IndexedSprite indexedSprite = Mockito.mock(IndexedSprite.class);
         IndexedSprite indexedSpriteToAdd = Mockito.mock(IndexedSprite.class);

--- a/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
+++ b/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class CommandInvokerTest {
+class CommandInvokerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
@@ -28,7 +28,7 @@ public class CommandInvokerTest {
     private transient CommandInvoker commandInvoker;
 
     @Test
-    public void shouldCallCommandCreatorOnlyOnceWhenCommandWasExecutedProperly() {
+    void shouldCallCommandCreatorOnlyOnceWhenCommandWasExecutedProperly() {
         // given
         HydrateReminderCommandArgs commandArgs = HydrateReminderCommandArgs.HYDRATE;
         Command hydrateCommand = Mockito.mock(HydrateCommand.class);
@@ -44,7 +44,7 @@ public class CommandInvokerTest {
     }
 
     @Test
-    public void shouldSendProperMessageWhenNotRecognizedCommandExceptionIsThrown() {
+    void shouldSendProperMessageWhenNotRecognizedCommandExceptionIsThrown() {
         // given
         String expectedExceptionMessage = new NotRecognizedCommandException("wrong").getReason();
         Command helpCommand = Mockito.mock(HelpCommand.class);
@@ -61,7 +61,7 @@ public class CommandInvokerTest {
     }
 
     @Test
-    public void shouldCallCommandCreatorTwiceWhenNotSupportedCommandExceptionIsThrown() {
+    void shouldCallCommandCreatorTwiceWhenNotSupportedCommandExceptionIsThrown() {
         // given
         HydrateReminderCommandArgs commandArgs = HydrateReminderCommandArgs.HYDRATE;
         CommandExecuted commandToExecute = new CommandExecuted("hr", new String[]{"hydrate"});
@@ -79,7 +79,7 @@ public class CommandInvokerTest {
     }
 
     @Test
-    public void shouldReturnNothingWhenIsNotHydrateCommand() {
+    void shouldReturnNothingWhenIsNotHydrateCommand() {
         // given
         CommandExecuted commandToExecute = new CommandExecuted("aa", new String[]{"hydrate"});
 
@@ -89,4 +89,3 @@ public class CommandInvokerTest {
     }
 
 }
-

--- a/src/test/java/com/hydratereminder/command/help/HelpCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/help/HelpCommandHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class HelpCommandHandlerTest {
+class HelpCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
@@ -18,7 +18,7 @@ public class HelpCommandHandlerTest {
     private transient HelpCommandHandler helpCommandHandler;
 
     @Test
-    public void shouldHandleHelpCommand() {
+    void shouldHandleHelpCommand() {
         // given
         final String possibleCommands = "next, prev, reset, hydrate, help, total";
         final String expectedMessage = "Available commands: ::hr " + possibleCommands;

--- a/src/test/java/com/hydratereminder/command/hydrate/HydrateCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/hydrate/HydrateCommandHandlerTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class HydrateCommandHandlerTest {
+class HydrateCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
@@ -21,7 +21,7 @@ public class HydrateCommandHandlerTest {
     private transient HydrateCommandHandler hydrateCommandHandler;
 
     @Test
-    public void shouldResetCurrentHydrateIntervalAndIncreaseHydrationBreaksWhenHydrateCommandIsCalled() {
+    void shouldResetCurrentHydrateIntervalAndIncreaseHydrationBreaksWhenHydrateCommandIsCalled() {
         //given and then
         hydrateCommandHandler.handle();
 
@@ -31,7 +31,7 @@ public class HydrateCommandHandlerTest {
     }
 
     @Test
-    public void shouldSendProperMessageWhenHydrateCommandIsCalled() {
+    void shouldSendProperMessageWhenHydrateCommandIsCalled() {
         //given
         String message = "Successfully hydrated before reminder interval finished";
 

--- a/src/test/java/com/hydratereminder/command/next/NextCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/next/NextCommandHandlerTest.java
@@ -1,9 +1,5 @@
 package com.hydratereminder.command.next;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-
 import com.hydratereminder.HydrateReminderPlugin;
 import com.hydratereminder.chat.ChatMessageSender;
 import org.junit.jupiter.api.Test;
@@ -12,22 +8,26 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class NextCommandHandlerTest {
+class NextCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
     @Mock
-    private transient  HydrateReminderPlugin hydrateReminderPlugin;
+    private transient HydrateReminderPlugin hydrateReminderPlugin;
     @InjectMocks
     private transient NextCommandHandler nextCommandHandler;
 
     @Test
-    public void shouldHandleNextCommand() {
+    void shouldHandleNextCommand() {
         // given
         final String expectedMessage = "5 hours until the next hydration break.";
         final Instant nextHydrateBreak = LocalDateTime.now()

--- a/src/test/java/com/hydratereminder/command/prev/PrevCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/prev/PrevCommandHandlerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class PrevCommandHandlerTest {
+class PrevCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
@@ -35,7 +35,7 @@ public class PrevCommandHandlerTest {
 
 
     @Test
-    public void shouldSendMessageSinceLastHydrationInterval() {
+    void shouldSendMessageSinceLastHydrationInterval() {
         //given
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofMinutes(100));
         final String timeSinceLastBreakAsString = "1 hours 40 minutes 0 seconds";
@@ -57,7 +57,7 @@ public class PrevCommandHandlerTest {
     }
 
     @Test
-    public void shouldReturnExpectedMessageWhenThereIsNoTimeSinceLastBreak() {
+    void shouldReturnExpectedMessageWhenThereIsNoTimeSinceLastBreak() {
         //given
         final Optional<Duration> timeSinceLastBreak = Optional.empty();
 
@@ -71,7 +71,7 @@ public class PrevCommandHandlerTest {
     }
 
     @Test
-    public void shouldReturnExpectedMessageWhenThereIsResetSinceLastBreak() {
+    void shouldReturnExpectedMessageWhenThereIsResetSinceLastBreak() {
         //given
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofSeconds(645));
         final String timeSinceLastBreakAsString = "10 minutes 45 seconds";
@@ -89,7 +89,7 @@ public class PrevCommandHandlerTest {
     }
 
     @Test
-    public void shouldReturnCorrectStringFormatOfHandleHydratePrevCommandMessage() {
+    void shouldReturnCorrectStringFormatOfHandleHydratePrevCommandMessage() {
         //given
         final Optional<Duration> timeSinceLastBreak = Optional.of(Duration.ofMinutes(130));
         final String timeSinceLastBreakAsString = "2 hours 10 minutes 0 seconds";

--- a/src/test/java/com/hydratereminder/command/reset/ResetCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/reset/ResetCommandHandlerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class ResetCommandHandlerTest {
+class ResetCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;
@@ -23,7 +23,7 @@ public class ResetCommandHandlerTest {
     private transient ResetCommandHandler resetCommandHandler;
 
     @Test
-    public void shouldResetHydrate() {
+    void shouldResetHydrate() {
         resetCommandHandler.handle();
 
         final String resetString = "Hydrate reminder interval has been successfully reset.";

--- a/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
+++ b/src/test/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionaryTest.java
@@ -14,7 +14,7 @@ import static com.hydratereminder.dictionary.HydrateBreakMessageDictionary.getRa
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class HydrateBreakMessageDictionaryTest {
+class HydrateBreakMessageDictionaryTest {
 
     @ParameterizedTest
     @CsvSource(delimiter = '|', value = {
@@ -28,16 +28,14 @@ public class HydrateBreakMessageDictionaryTest {
             "MOTIVATIONAL | Thousands Have Lived Without Love, Not One Without Water. Take a sip | 13",
             "AGGRESSIVE | You gotta drink some Water, Yeah! | 9",
     })
-    public void shouldChooseCorrectMessageBasedOnPersonalityType (
-            HydrateReminderPersonalityType personalityType, String expectedMessage, int value)
-    {
-            try (MockedConstruction<SecureRandom> ignored = Mockito.mockConstruction(SecureRandom.class, (mock, context) ->
-                    Mockito.when(mock.nextInt(Mockito.anyInt())).thenReturn(value)
-            ))
-            {
-                String givenMessage = getRandomHydrateBreakMessageForPersonality(personalityType);
+    void shouldChooseCorrectMessageBasedOnPersonalityType(
+            HydrateReminderPersonalityType personalityType, String expectedMessage, int value) {
+        try (MockedConstruction<SecureRandom> ignored = Mockito.mockConstruction(SecureRandom.class, (mock, context) ->
+                Mockito.when(mock.nextInt(Mockito.anyInt())).thenReturn(value)
+        )) {
+            String givenMessage = getRandomHydrateBreakMessageForPersonality(personalityType);
 
-                assertEquals(givenMessage, expectedMessage);
-            }
+            assertEquals(givenMessage, expectedMessage);
+        }
     }
 }

--- a/src/test/java/com/hydratereminder/dictionary/HydrateWelcomeMessageDictionaryTest.java
+++ b/src/test/java/com/hydratereminder/dictionary/HydrateWelcomeMessageDictionaryTest.java
@@ -2,7 +2,6 @@ package com.hydratereminder.dictionary;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -12,10 +11,10 @@ import java.security.SecureRandom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class HydrateWelcomeMessageDictionaryTest {
+class HydrateWelcomeMessageDictionaryTest {
 
     @Test
-    public void shouldGetRandomWelcomeMessage() {
+    void shouldGetRandomWelcomeMessage() {
         try (MockedConstruction<SecureRandom> mockRandom = Mockito.mockConstruction(SecureRandom.class, (mock, context) -> {
             Mockito.when(mock.nextInt(Mockito.anyInt())).thenReturn(4);
         })) {


### PR DESCRIPTION
## Associated Issue
Fixing Codacy issue:  JUnit 5 tests should be package-private.
Not have issue associated.

## Implemented Solution
- Deleted public in test classes and methods.
- Removed wild card imports from test classes
- Reformat test classes

## Testing Details
Run Unit tests after changes. All passed.

Operating System:  Windows 11
RuneLite Version:  N/A

## Screenshots
![image](https://user-images.githubusercontent.com/94566117/194613720-98a47f27-2816-4e86-8e0a-29e926e6caaa.png)

