### PR TITLE
Add assert

### DIFF
--- a/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
+++ b/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
@@ -84,7 +84,7 @@ public class CommandInvokerTest {
 
         // when and then
         commandInvoker.invokeCommand(commandToExecute);
-        verify(commandCreator,never()).createFrom(any());
+        verify(commandCreator,never()).createFrom(any()); // used verify to assert 
 
     }
 

--- a/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
+++ b/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
@@ -14,8 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CommandInvokerTest {
@@ -85,6 +84,7 @@ public class CommandInvokerTest {
 
         // when and then
         commandInvoker.invokeCommand(commandToExecute);
+        verify(commandCreator,never()).createFrom(any());
 
     }
 


### PR DESCRIPTION
## Associated Issue

Closes #296 

## Implemented Solution

added assert using verify method to check that commandCreator.createFrom(commandType) is never called when the invalid command is passed in as a parameter to invokeCommand.

## Testing Details

Operating System: Ubuntu 22.04.1 LTS 64-bit
RuneLite Version: 1.9.0

## Screenshots

