### PR TITLE
﻿Add Santa personality type for hydrate reminder. Closes #268

### DIFF
--- a/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
+++ b/src/main/java/com/hydratereminder/HydrateReminderPersonalityType.java
@@ -17,7 +17,8 @@ public enum HydrateReminderPersonalityType
     RANDOM("Random"),
     PIRATE("Pirate"),
     WIZARD("Wizard"),
-    CARING("Caring");  
+    CARING("Caring"),
+    SANTA("Santa");
 
 
 

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -84,7 +84,7 @@ public class HydrateBreakMessageDictionary {
             );
 
     /**
-     * Hydrate Reminder interval break text to display in caring form
+     * Hydrate Reminder interval break text to display in nerdy form
      */
     private static final List<String> HYDRATE_BREAK_NERDY_TEXT_LIST =
             Collections.unmodifiableList(
@@ -118,7 +118,7 @@ public class HydrateBreakMessageDictionary {
                     add("You can keep my heart but bring me back to life by drinking some water!");
                     add("Stop making me think about you! I'm busy drinking water");
                     add("You make my heart melt! Please drink some water");
-                    add("Just a note to remind you I'm thinking about you and drinkind some water");
+                    add("Just a note to remind you I'm thinking about you and drinking some water");
                     add("As the flower needs the sunshine, I need you in my life. Please drink some water");
                     add("Your heart is so full of love, and I'm lucky enough to find a place there. Please drink some water");
                     add("In all the world, there is no heart for me like yours. Drink some water to keep me in your heart.");
@@ -242,6 +242,30 @@ public class HydrateBreakMessageDictionary {
                     }}
             );
 
+    /**
+     * Hydrate Reminder interval break text to display in Santa form
+     */
+    private static final List<String> HYDRATE_BREAK_SANTA_TEXT_LIST =
+            Collections.unmodifiableList(
+                    new ArrayList<String>() {{
+                        add("Smile and drink some water! Santa's coming to town");
+                        add("All I want for Christmas is you....drinking enough water");
+                        add("Ho ho ho! Time to drink");
+                        add("My elves are really busy but always remember to drink water. What about you?");
+                        add("Let's sit around the Christmas tree and drink some water together");
+                        add("Last year I gave you a cup...so fill it with water and drink some right now...");
+                        add("Have you been naughty and kept forgetting about hydration breaks?");
+                        add("I brought you some presents and bottles of water, let's drink");
+                        add("Don't be shy kiddo, come and have a drink with Santa");
+                        add("I still have a lot of chimneys to visit, but first, let's have a little hydration break together");
+                        add("You know, Mrs. Claus gets really mad at me when I forget about water breaks");
+                        add("Ho, ho, ho! Hydration break");
+                        add("Look at my Rudolph here, he's always hydrated! Are you?");
+                        add("Here is your Christmas gift, but remember - the best gift for future you is drinking enough water");
+                        add("Please drink a glass of water. Merry Christmas");
+                    }}
+            );
+
 
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {
@@ -284,6 +308,9 @@ public class HydrateBreakMessageDictionary {
                 break;
             case AGGRESSIVE:
                 breakMessage = getRandomBreakMessage(HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
+                break;
+            case SANTA:
+                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_SANTA_TEXT_LIST);
                 break;
             case RANDOM:
                 breakMessage = getRandomPersonalityMessage();


### PR DESCRIPTION
* Add new personality type
* Add list of messages for new personality type
* Fix 2 typos in message dictionary class

## Associated Issue
Closes #268 

## Implemented Solution
- Added new value for HydrateReminderPersonalityType enum: SANTA
- Added list of messages for SANTA
- By the way I fixed 2 typos in HydrateWelcomeMessageDictionary: 1. incorrect type in doc comment 2. typo in the message of romantic type
To push my changes, I needed to resolve conflicts with https://github.com/jmakhack/hydrate-reminder/issues/262

## Testing Details
Tested by running HydrateReminderTest.java and verifying the changes in the application.
Operating System: Windows 10
RuneLite Version:  1.9.0

## Screenshots
![santa](https://user-images.githubusercontent.com/17500766/194729899-c3fe6496-9b2b-4657-880e-8c9b51fe80e9.png)

![drinkBreak](https://user-images.githubusercontent.com/17500766/194729974-6d685329-25a3-4449-8518-f4b96783ccc1.png)
