### PR TITLE
adde debug log level guard

### DIFF
--- a/src/main/java/com/hydratereminder/chat/ChatMessageSender.java
+++ b/src/main/java/com/hydratereminder/chat/ChatMessageSender.java
@@ -49,7 +49,9 @@ public class ChatMessageSender {
     public void sendHydrateReminderChatMessage(String message) {
         final ChatMessageType chatMessageType = chatMessageTypeProvider.getChatNotificationMessageType();
         sendHydrateEmojiChatMessage(chatMessageType, message);
-        log.debug(String.format("Successfully sent chat notification of type: %s", chatMessageType.toString()));
+        if(log.isDebugEnabled()){
+            log.debug(String.format("Successfully sent chat notification of type: %s", chatMessageType.toString()));
+        }
     }
 
     /**

--- a/src/main/java/com/hydratereminder/chat/ChatMessageSender.java
+++ b/src/main/java/com/hydratereminder/chat/ChatMessageSender.java
@@ -49,7 +49,7 @@ public class ChatMessageSender {
     public void sendHydrateReminderChatMessage(String message) {
         final ChatMessageType chatMessageType = chatMessageTypeProvider.getChatNotificationMessageType();
         sendHydrateEmojiChatMessage(chatMessageType, message);
-        if(log.isDebugEnabled()){
+        if (log.isDebugEnabled()) {
             log.debug(String.format("Successfully sent chat notification of type: %s", chatMessageType.toString()));
         }
     }


### PR DESCRIPTION
## Associated Issue

Closes #329 

## Implemented Solution
surrounded the log statement with a log level guard to prevent unnecessary log printing