### PR TITLE
fix: add super() in constructor

### DIFF
--- a/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
@@ -8,6 +8,7 @@ public class NotRecognizedCommandException extends RuntimeException {
     private static final long serialVersionUID = 4328743L;
 
     public NotRecognizedCommandException(String unsupportedCommandName) {
+        super();
         this.reason = String.format(
                 "%s%s %s is not supported command",
                 RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_ALIAS, unsupportedCommandName

--- a/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
@@ -10,6 +10,7 @@ public class NotSupportedCommandException extends RuntimeException {
     private static final long serialVersionUID = 4328741L;
 
     public NotSupportedCommandException(HydrateReminderCommandArgs unrecognizedCommandName) {
+        super();
         this.reason = String.format(
                 "%s%s %s is not a valid command",
                 RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_ALIAS, unrecognizedCommandName


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #330 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Added **super()** in `src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java` and `src/main/java/com/hydratereminder/command/NotSupportedCommandException.java`

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: Windows 11
RuneLite Version: 1.9.0
