### PR TITLE
modify command exception to use message instead of reason

### DIFF
--- a/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotRecognizedCommandException.java
@@ -4,18 +4,12 @@ import static com.hydratereminder.Commons.HYDRATE_COMMAND_ALIAS;
 import static com.hydratereminder.Commons.RUNELITE_COMMAND_PREFIX;
 
 public class NotRecognizedCommandException extends RuntimeException {
-    private final String reason;
     private static final long serialVersionUID = 4328743L;
 
     public NotRecognizedCommandException(String unsupportedCommandName) {
-        super();
-        this.reason = String.format(
+        super(String.format(
                 "%s%s %s is not supported command",
                 RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_ALIAS, unsupportedCommandName
-        );
-    }
-
-    public String getReason() {
-        return reason;
+        ));
     }
 }

--- a/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
+++ b/src/main/java/com/hydratereminder/command/NotSupportedCommandException.java
@@ -6,18 +6,11 @@ import static com.hydratereminder.Commons.HYDRATE_COMMAND_ALIAS;
 import static com.hydratereminder.Commons.RUNELITE_COMMAND_PREFIX;
 
 public class NotSupportedCommandException extends RuntimeException {
-    private final String reason;
     private static final long serialVersionUID = 4328741L;
 
     public NotSupportedCommandException(HydrateReminderCommandArgs unrecognizedCommandName) {
-        super();
-        this.reason = String.format(
+        super(String.format(
                 "%s%s %s is not a valid command",
-                RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_ALIAS, unrecognizedCommandName
-        );
-    }
-
-    public String getReason() {
-        return reason;
+                RUNELITE_COMMAND_PREFIX, HYDRATE_COMMAND_ALIAS, unrecognizedCommandName));
     }
 }

--- a/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
+++ b/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
@@ -14,9 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommandInvokerTest {
@@ -47,7 +45,7 @@ class CommandInvokerTest {
     @Test
     void shouldSendProperMessageWhenNotRecognizedCommandExceptionIsThrown() {
         // given
-        String expectedExceptionMessage = new NotRecognizedCommandException("wrong").getReason();
+        String expectedExceptionMessage = new NotRecognizedCommandException("wrong").getMessage();
         Command helpCommand = Mockito.mock(HelpCommand.class);
         CommandExecuted commandToExecute = new CommandExecuted("hr", new String[]{"wrong"});
 

--- a/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
+++ b/src/test/java/com/hydratereminder/command/CommandInvokerTest.java
@@ -9,12 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class CommandInvokerTest {
@@ -30,7 +32,7 @@ class CommandInvokerTest {
     void shouldCallCommandCreatorOnlyOnceWhenCommandWasExecutedProperly() {
         // given
         HydrateReminderCommandArgs commandArgs = HydrateReminderCommandArgs.HYDRATE;
-        Command hydrateCommand = Mockito.mock(HydrateCommand.class);
+        Command hydrateCommand = mock(HydrateCommand.class);
         CommandExecuted commandToExecute = new CommandExecuted("hr", new String[]{"hydrate"});
 
         given(commandCreator.createFrom(commandArgs)).willReturn(hydrateCommand);
@@ -46,7 +48,7 @@ class CommandInvokerTest {
     void shouldSendProperMessageWhenNotRecognizedCommandExceptionIsThrown() {
         // given
         String expectedExceptionMessage = new NotRecognizedCommandException("wrong").getMessage();
-        Command helpCommand = Mockito.mock(HelpCommand.class);
+        Command helpCommand = mock(HelpCommand.class);
         CommandExecuted commandToExecute = new CommandExecuted("hr", new String[]{"wrong"});
 
         given(commandCreator.createFrom(HydrateReminderCommandArgs.HELP)).willReturn(helpCommand);
@@ -64,7 +66,7 @@ class CommandInvokerTest {
         // given
         HydrateReminderCommandArgs commandArgs = HydrateReminderCommandArgs.HYDRATE;
         CommandExecuted commandToExecute = new CommandExecuted("hr", new String[]{"hydrate"});
-        Command helpCommand = Mockito.mock(HelpCommand.class);
+        Command helpCommand = mock(HelpCommand.class);
 
         given(commandCreator.createFrom(commandArgs)).willThrow(NotSupportedCommandException.class);
         given(commandCreator.createFrom(HydrateReminderCommandArgs.HELP)).willReturn(helpCommand);


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #352 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
Modify command exception to use message instead of reason.
Missing a test for NotSupportedCommandException.

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
Operating System: Windows
RuneLite Version: 1.9.1

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
