### PR TITLE
Removing public access modifier to declare test package private

### DIFF
--- a/src/test/java/com/hydratereminder/command/total/TotalCommandHandlerTest.java
+++ b/src/test/java/com/hydratereminder/command/total/TotalCommandHandlerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TotalCommandHandlerTest {
+class TotalCommandHandlerTest {
 
     @Mock
     private transient ChatMessageSender chatMessageSender;


### PR DESCRIPTION
Closes #327 

## Implemented Solution
Removed public access modifier from the class to make it package private