### PR TITLE
Refactor getRandomHydrateBreakMessageForPersonality method

### DIFF
--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -296,7 +296,7 @@ public class HydrateBreakMessageDictionary {
      */
     private static final Map<HydrateReminderPersonalityType, List<String>> HYDRATE_REMINDER_PERSONALITY_MAP;
     static {
-        Map<HydrateReminderPersonalityType, List<String>> mutableMap = new ConcurrentHashMap<>();
+        final Map<HydrateReminderPersonalityType, List<String>> mutableMap = new ConcurrentHashMap<>();
         mutableMap.put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
         mutableMap.put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
         mutableMap.put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -4,7 +4,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -290,22 +290,26 @@ public class HydrateBreakMessageDictionary {
                 }}
             );
 
-  private static final Map<HydrateReminderPersonalityType, List<String>> hydratePersonalityMap =
-      Collections.unmodifiableMap(
-          new HashMap<HydrateReminderPersonalityType, List<String>>() {{
-              put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
-              put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
-              put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);
-              put(HydrateReminderPersonalityType.ROMANTIC, HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
-              put(HydrateReminderPersonalityType.POLITE, HYDRATE_BREAK_POLITE_TEXT_LIST);
-              put(HydrateReminderPersonalityType.NERDY, HYDRATE_BREAK_NERDY_TEXT_LIST);
-              put(HydrateReminderPersonalityType.PIRATE, HYDRATE_BREAK_PIRATE_TEXT_LIST);
-              put(HydrateReminderPersonalityType.WIZARD, HYDRATE_BREAK_WIZARD_TEXT_LIST);
-              put(HydrateReminderPersonalityType.MOTIVATIONAL, HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
-              put(HydrateReminderPersonalityType.AGGRESSIVE, HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
-              put(HydrateReminderPersonalityType.SANTA, HYDRATE_BREAK_SANTA_TEXT_LIST);
-              put(HydrateReminderPersonalityType.KAWAII, HYDRATE_BREAK_KAWAII_TEXT_LIST);
-          }});
+    /**
+     * Mapping of {@link HydrateReminderPersonalityType} to the corresponding
+     * Hydrate Reminder interval break text to be displayed
+     */
+    private static final Map<HydrateReminderPersonalityType, List<String>> HYDRATE_REMINDER_PERSONALITY_MAP =
+            Collections.unmodifiableMap(
+                    new EnumMap<HydrateReminderPersonalityType, List<String>>(HydrateReminderPersonalityType.class) {{
+                        put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.ROMANTIC, HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.POLITE, HYDRATE_BREAK_POLITE_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.NERDY, HYDRATE_BREAK_NERDY_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.PIRATE, HYDRATE_BREAK_PIRATE_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.WIZARD, HYDRATE_BREAK_WIZARD_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.MOTIVATIONAL, HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.AGGRESSIVE, HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.SANTA, HYDRATE_BREAK_SANTA_TEXT_LIST);
+                        put(HydrateReminderPersonalityType.KAWAII, HYDRATE_BREAK_KAWAII_TEXT_LIST);
+                    }});
 
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {
@@ -316,10 +320,14 @@ public class HydrateBreakMessageDictionary {
 
     public static String getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType personalityType)
     {
-        if (personalityType == HydrateReminderPersonalityType.RANDOM)
-            return getRandomPersonalityMessage();
-        else
-            return getRandomBreakMessage(hydratePersonalityMap.get(personalityType));
+        String breakMessage;
+        if (personalityType == HydrateReminderPersonalityType.RANDOM) {
+            breakMessage = getRandomPersonalityMessage();
+        }
+        else {
+            breakMessage = getRandomBreakMessage(HYDRATE_REMINDER_PERSONALITY_MAP.get(personalityType));
+        }
+        return breakMessage;
     }
 
     /**

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -4,9 +4,9 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.hydratereminder.HydrateReminderPersonalityType;
@@ -294,22 +294,23 @@ public class HydrateBreakMessageDictionary {
      * Mapping of {@link HydrateReminderPersonalityType} to the corresponding
      * Hydrate Reminder interval break text to be displayed
      */
-    private static final Map<HydrateReminderPersonalityType, List<String>> HYDRATE_REMINDER_PERSONALITY_MAP =
-            Collections.unmodifiableMap(
-                    new EnumMap<HydrateReminderPersonalityType, List<String>>(HydrateReminderPersonalityType.class) {{
-                        put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.ROMANTIC, HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.POLITE, HYDRATE_BREAK_POLITE_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.NERDY, HYDRATE_BREAK_NERDY_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.PIRATE, HYDRATE_BREAK_PIRATE_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.WIZARD, HYDRATE_BREAK_WIZARD_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.MOTIVATIONAL, HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.AGGRESSIVE, HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.SANTA, HYDRATE_BREAK_SANTA_TEXT_LIST);
-                        put(HydrateReminderPersonalityType.KAWAII, HYDRATE_BREAK_KAWAII_TEXT_LIST);
-                    }});
+    private static final Map<HydrateReminderPersonalityType, List<String>> HYDRATE_REMINDER_PERSONALITY_MAP;
+    static {
+        Map<HydrateReminderPersonalityType, List<String>> mutableMap = new ConcurrentHashMap<>();
+        mutableMap.put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.ROMANTIC, HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.POLITE, HYDRATE_BREAK_POLITE_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.NERDY, HYDRATE_BREAK_NERDY_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.PIRATE, HYDRATE_BREAK_PIRATE_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.WIZARD, HYDRATE_BREAK_WIZARD_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.MOTIVATIONAL, HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.AGGRESSIVE, HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.SANTA, HYDRATE_BREAK_SANTA_TEXT_LIST);
+        mutableMap.put(HydrateReminderPersonalityType.KAWAII, HYDRATE_BREAK_KAWAII_TEXT_LIST);
+        HYDRATE_REMINDER_PERSONALITY_MAP = Collections.unmodifiableMap(mutableMap);
+    }
 
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {

--- a/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
+++ b/src/main/java/com/hydratereminder/dictionary/HydrateBreakMessageDictionary.java
@@ -4,7 +4,9 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.hydratereminder.HydrateReminderPersonalityType;
@@ -288,6 +290,22 @@ public class HydrateBreakMessageDictionary {
                 }}
             );
 
+  private static final Map<HydrateReminderPersonalityType, List<String>> hydratePersonalityMap =
+      Collections.unmodifiableMap(
+          new HashMap<HydrateReminderPersonalityType, List<String>>() {{
+              put(HydrateReminderPersonalityType.SIMPLE, HYDRATE_BREAK_SIMPLE_TEXT_LIST);
+              put(HydrateReminderPersonalityType.FUN, HYDRATE_BREAK_FUNNY_TEXT_LIST);
+              put(HydrateReminderPersonalityType.CARING, HYDRATE_BREAK_CARING_TEXT_LIST);
+              put(HydrateReminderPersonalityType.ROMANTIC, HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
+              put(HydrateReminderPersonalityType.POLITE, HYDRATE_BREAK_POLITE_TEXT_LIST);
+              put(HydrateReminderPersonalityType.NERDY, HYDRATE_BREAK_NERDY_TEXT_LIST);
+              put(HydrateReminderPersonalityType.PIRATE, HYDRATE_BREAK_PIRATE_TEXT_LIST);
+              put(HydrateReminderPersonalityType.WIZARD, HYDRATE_BREAK_WIZARD_TEXT_LIST);
+              put(HydrateReminderPersonalityType.MOTIVATIONAL, HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
+              put(HydrateReminderPersonalityType.AGGRESSIVE, HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
+              put(HydrateReminderPersonalityType.SANTA, HYDRATE_BREAK_SANTA_TEXT_LIST);
+              put(HydrateReminderPersonalityType.KAWAII, HYDRATE_BREAK_KAWAII_TEXT_LIST);
+          }});
 
     private static String getRandomBreakMessage(List<String> hydrateBreakTextList)
     {
@@ -298,52 +316,10 @@ public class HydrateBreakMessageDictionary {
 
     public static String getRandomHydrateBreakMessageForPersonality(HydrateReminderPersonalityType personalityType)
     {
-        String breakMessage;
-        switch (personalityType)
-        {
-            case SIMPLE:
-                breakMessage = HYDRATE_BREAK_SIMPLE_TEXT_LIST.get(0);
-                break;
-            case FUN:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_FUNNY_TEXT_LIST);
-                break;
-            case CARING:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_CARING_TEXT_LIST);
-                break;
-            case ROMANTIC:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_ROMANTIC_TEXT_LIST);
-                break;
-            case POLITE:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_POLITE_TEXT_LIST);
-                break;
-            case NERDY:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_NERDY_TEXT_LIST);
-                 break;
-            case PIRATE:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_PIRATE_TEXT_LIST);
-                break;
-            case WIZARD:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_WIZARD_TEXT_LIST);
-                break;
-            case MOTIVATIONAL:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_MOTIVATIONAL_TEXT_LIST);
-                break;
-            case AGGRESSIVE:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_AGGRESSIVE_TEXT_LIST);
-                break;
-            case SANTA:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_SANTA_TEXT_LIST);
-                break;
-            case KAWAII:
-                breakMessage = getRandomBreakMessage(HYDRATE_BREAK_KAWAII_TEXT_LIST);
-                break;
-            case RANDOM:
-                breakMessage = getRandomPersonalityMessage();
-                break;
-            default:
-                throw new IllegalStateException("Provided personality type is not supported");
-        }
-        return breakMessage;
+        if (personalityType == HydrateReminderPersonalityType.RANDOM)
+            return getRandomPersonalityMessage();
+        else
+            return getRandomBreakMessage(hydratePersonalityMap.get(personalityType));
     }
 
     /**


### PR DESCRIPTION
## Associated Issue
<!---
This project only accepts pull requests that are associated to currently open issues
If submitting a new enhancement or change in functionality, please open an issue first for discussion
If making a bugfix, it should be associated with an existing issue with a description and reproduction steps
Please link to the issue below:
-->
Closes #294 

## Implemented Solution
<!---
Please write a description for your solution here.
Have you encountered any issues along the way?
Are there any caveats to note?
-->
As detailed in the issue description, this PR removes the switch case pattern in the ```getRandomHydrateBreakMessageForPersonality``` method and instead creates a map that links the personalityType to the corresponding list of hydrate break messages

## Testing Details
<!---
Please describe in detail how you tested your changes.
Include what Operating System and RuneLite version was used in testing.
Describe the plugin configurations that this change was tested with.
-->
No change to existing behaviour. Ran the unit tests and observed no failure related to the PR.
Operating System: 
RuneLite Version: 

## Screenshots
<!---
If relevant, include any screenshots or gifs that show the enhancement/bugfix working in the client.
-->
